### PR TITLE
Use stock Harmony with direct calls to MonoMod where necessary

### DIFF
--- a/BeaverBuddies/BeaverBuddies.csproj
+++ b/BeaverBuddies/BeaverBuddies.csproj
@@ -28,27 +28,30 @@
     <TimberbornDataPath Condition="'$(TimberbornDataPath)' == ''">$(TimberbornPath)Timberborn_Data\</TimberbornDataPath>
     <TimberbornManagedPath>$(TimberbornDataPath)Managed\</TimberbornManagedPath>
     <!-- Include HarmonyX file inside $(BeaverBuddiesModsPath) -->
-    <includeHarmonyX>true</includeHarmonyX>
     <NuGetPackagesDir>$(UserProfile)\.nuget\packages\</NuGetPackagesDir>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <Target Name="CheckEnv" BeforeTargets="BeforeBuild">
     <Warning Text="TimberbornPath property is deprecated, use the more specific TimberbornDataPath instead" Condition="'$(TimberbornDataPath)' == ''"/>
     <Error Text="TimberbornDataPath property directory not found" Condition="!Exists('$(TimberbornDataPath)')"/>
-    <Error Text="BepInExPath property directory not found" Condition="!Exists('$(BepInExPath)')"/>
+    <Error Text="HarmonyPath property directory not found" Condition="!Exists('$(HarmonyPath)')"/>
     <Error Text="ModSettingsPath property directory not found" Condition="!Exists('$(ModSettingsPath)')"/>
     <Error Text="DocumentsPath property directory not found" Condition="!Exists('$(DocumentsPath)')"/>
   </Target>
 
   <!-- NuGet -->
-  <ItemGroup> 
+  <ItemGroup>
     <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.3">
       <PrivateAssets>all</PrivateAssets>
       <PublicizeCompilerGenerated>false</PublicizeCompilerGenerated>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference> 
     <PackageReference Include="System.Collections.Immutable" Version="9.0.0" />
-  </ItemGroup> 
+    <PackageReference Include="MonoMod.Core" Version="1.3.4" />
+    <PackageReference Include="MonoMod.RuntimeDetour" Version="25.3.4" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.*" />
+  </ItemGroup>
 
   <!-- OutSide Project -->
   <ItemGroup>
@@ -57,11 +60,9 @@
 
   <!-- Reference DLL -->
   <ItemGroup>
-    <!-- BepInEx (Harmony, Mono.Cecil & MonoMod DLL) -->
-    <Reference Include="$(BepInExPath)core\0Harmony.dll" Private="$(includeHarmonyX)" />
-    <Reference Include="$(BepInExPath)core\Mono.Cecil.*.dll" Private="$(includeHarmonyX)" />
-    <Reference Include="$(BepInExPath)core\MonoMod.*.dll" Private="$(includeHarmonyX)" />
-    
+    <!-- Harmony -->
+    <Reference Include="$(HarmonyPath)0Harmony.dll" Private="false" />
+
     <!-- Timberborn DLL & Publicize (BepInEx.AssemblyPublicizer.MSBuild) -->
     <Reference Include="$(TimberbornManagedPath)com.rlabrecque.steamworks.net.dll" Private="false" />
     <Reference Include="$(TimberbornManagedPath)Bindito.Core.dll" Private="false" />

--- a/BeaverBuddies/DeterminismService.cs
+++ b/BeaverBuddies/DeterminismService.cs
@@ -8,10 +8,14 @@ using BeaverBuddies.DesyncDetecter;
 using BeaverBuddies.IO;
 using Bindito.Core.Internal;
 using HarmonyLib;
+using MonoMod.RuntimeDetour;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Timberborn.Analytics;
 using Timberborn.Autosaving;
@@ -688,24 +692,35 @@ namespace BeaverBuddies
             return true;
         }
     }
-
-    [HarmonyPatch(typeof(GameSaver), nameof(GameSaver.Save), typeof(QueuedSave))]
-    public class GameSaverSavePatcher
-    {
+    
+    public class GameSaverSavePatcher {
         public static bool IsSaving { get; set; }
 
-        static bool Prefix(GameSaver __instance, QueuedSave queuedSave)
-        {
-            if (IsSaving || EventIO.IsNull) return true;
+        public static void Install() {
+            Debug.Log(typeof(System.Reflection.Emit.DynamicMethod).AssemblyQualifiedName);
+
+            var hook = new Hook(
+                typeof(GameSaver).GetMethod(nameof(GameSaver.Save), BindingFlags.Instance | BindingFlags.NonPublic),
+                Save
+            );
+        }
+
+        private static void Save(GameSaver __instance, QueuedSave queuedSave) {
+            if (IsSaving || EventIO.IsNull) {
+                __instance.Save(queuedSave);
+                return;
+            }
             TickingService ts = GetSingleton<TickingService>();
-            if (ts == null) return true;
+            if (ts == null) {
+                __instance.Save(queuedSave);
+                return;
+            }
             ts.FinishFullTickAndThen(() =>
             {
                 IsSaving = true;
                 __instance.Save(queuedSave);
                 IsSaving = false;
             });
-            return false;
         }
     }
 
@@ -837,21 +852,24 @@ namespace BeaverBuddies
         }
     }
 
-    [HarmonyPatch(typeof(Time), nameof(Time.time), MethodType.Getter)]
-    public class TimeTimePatcher
-    {
+    public class TimeTimePatcher {
         private static float time = 0;
 
-        public static void SetTicksSinceLoaded(int ticks)
-        {
+        public static void SetTicksSinceLoaded(int ticks) {
             time = ticks * Time.fixedDeltaTime;
         }
 
-        static bool Prefix(ref float __result)
+        public static void Install() {
+            var hook = new Hook(
+                typeof(Time).GetProperty(nameof(Time.time)).GetGetMethod(),
+                GetTime
+            );
+        }
+
+        static float GetTime(Time __instance)
         {
-            if (EventIO.IsNull) return true;
-            __result = time;
-            return false;
+            if (EventIO.IsNull) return Time.time;
+            return time;
         }
     }
 

--- a/BeaverBuddies/DeterminismService.cs
+++ b/BeaverBuddies/DeterminismService.cs
@@ -700,13 +700,14 @@ namespace BeaverBuddies
     // see https://github.com/pardeike/Harmony/issues/563#issuecomment-1889259983.
     // this uses Hook from MonoMod.RuntimeDetours instead.
     public class GameSaverSavePatcher {
+        private static Hook hook;
         public static bool IsSaving { get; set; }
 
         public static void Install() {
             Debug.Log(typeof(System.Reflection.Emit.DynamicMethod).AssemblyQualifiedName);
 
-            // no need to clean up, this hook is intended to be permanent.
-            new Hook(
+            // holding a reference to the hook keeps it active.
+            hook = new Hook(
                 typeof(GameSaver).GetMethod(nameof(GameSaver.Save), BindingFlags.Instance | BindingFlags.NonPublic),
                 Save
             );
@@ -863,6 +864,7 @@ namespace BeaverBuddies
     // stock Harmony doesn't support patching native code & neither does MonoMod.RuntimeDetours.
     // this uses low-level MonoMod.Core directly.
     public class TimeTimePatcher {
+        private static SimpleNativeDetour detour;
         private static float time = 0;
 
         public static void SetTicksSinceLoaded(int ticks) {
@@ -876,19 +878,20 @@ namespace BeaverBuddies
             PlatformTriple.Current.PinMethodIfNeeded(original_method);
             var replacement_pointer = Marshal.GetFunctionPointerForDelegate(GetTime);
 
-            // we'd ideally like to use CreateNativeDetour.
+            // using CreateNativeDetour here would be ideal.
             // it's capable of generate an alternate entrypoint to access the original native method.
             // however, native MacOS doesn't suppoert ArchitectureFeature.CreateAltEntryPoint.
-            // therefore we have to recklessly overwrite & use a hack to make do, see below.
-            // again no need to clean up, this hook is intended to be permanent.
-            PlatformTriple.Current.CreateNativeDetour(
+            // using CreateSimpleDetour instead irretrievably overwrites the method.
+            // this forces using make do without the original, see below.
+            // again with the detour, holding a reference keeps it active.
+            detour = PlatformTriple.Current.CreateSimpleDetour(
                 original_pointer,
                 replacement_pointer
             );
         }
 
         static float GetTime() {
-            // this is our hack to make do; TimberBorn doesn't use timeAsDouble.
+            // this is how we make do without original; TimberBorn doesn't use timeAsDouble.
             // as long as that holds that means we don't need to patch it.
             // therefore we can use it to reconstruct the now-inaccessible Time.time.
             if (EventIO.IsNull) return (float) Time.timeAsDouble;

--- a/BeaverBuddies/DeterminismService.cs
+++ b/BeaverBuddies/DeterminismService.cs
@@ -870,22 +870,28 @@ namespace BeaverBuddies
         }
 
         public static void Install() {
-            Debug.Log(typeof(Time).GetProperty(nameof(Time.time)).GetGetMethod().GetMethodBody());
-            Debug.Log(PlatformTriple.Current.SupportedFeatures.Has(ArchitectureFeature.CreateAltEntryPoint));
-
+            // get pointers to the original & replacement methods.
             var original_method = typeof(Time).GetProperty(nameof(Time.time)).GetGetMethod();
             var original_pointer = PlatformTriple.Current.GetNativeMethodBody(original_method);
             PlatformTriple.Current.PinMethodIfNeeded(original_method);
             var replacement_pointer = Marshal.GetFunctionPointerForDelegate(GetTime);
 
-            var detour = PlatformTriple.Current.CreateSimpleDetour(
+            // we'd ideally like to use CreateNativeDetour.
+            // it's capable of generate an alternate entrypoint to access the original native method.
+            // however, native MacOS doesn't suppoert ArchitectureFeature.CreateAltEntryPoint.
+            // therefore we have to recklessly overwrite & use a hack to make do, see below.
+            var detour = PlatformTriple.Current.CreateNativeDetour(
                 original_pointer,
                 replacement_pointer
             );
+            var backup_pointer = detour.AltEntry;
         }
 
         static float GetTime() {
-            if (EventIO.IsNull) return 0;
+            // this is our hack to make do; TimberBorn doesn't use timeAsDouble.
+            // as long as that holds that means we don't need to patch it.
+            // therefore we can use it to reconstruct the now-inaccessible Time.time.
+            if (EventIO.IsNull) return (float) Time.timeAsDouble;
             return time;
         }
     }

--- a/BeaverBuddies/DeterminismService.cs
+++ b/BeaverBuddies/DeterminismService.cs
@@ -713,20 +713,20 @@ namespace BeaverBuddies
             );
         }
 
-        private static void Save(GameSaver __instance, QueuedSave queuedSave) {
+        private static void Save(Action<GameSaver, QueuedSave> original, GameSaver instance, QueuedSave queuedSave) {
             if (IsSaving || EventIO.IsNull) {
-                __instance.Save(queuedSave);
+                original(instance, queuedSave);
                 return;
             }
             TickingService ts = GetSingleton<TickingService>();
             if (ts == null) {
-                __instance.Save(queuedSave);
+                original(instance, queuedSave);
                 return;
             }
             ts.FinishFullTickAndThen(() =>
             {
                 IsSaving = true;
-                __instance.Save(queuedSave);
+                original(instance, queuedSave);
                 IsSaving = false;
             });
         }

--- a/BeaverBuddies/DeterminismService.cs
+++ b/BeaverBuddies/DeterminismService.cs
@@ -695,13 +695,18 @@ namespace BeaverBuddies
         }
     }
     
+    // the original GameSaver.Save includes a try-catch-when block.
+    // stock Harmony doesn't support patching methods with such a block.
+    // see https://github.com/pardeike/Harmony/issues/563#issuecomment-1889259983.
+    // this uses Hook from MonoMod.RuntimeDetours instead.
     public class GameSaverSavePatcher {
         public static bool IsSaving { get; set; }
 
         public static void Install() {
             Debug.Log(typeof(System.Reflection.Emit.DynamicMethod).AssemblyQualifiedName);
 
-            var hook = new Hook(
+            // no need to clean up, this hook is intended to be permanent.
+            new Hook(
                 typeof(GameSaver).GetMethod(nameof(GameSaver.Save), BindingFlags.Instance | BindingFlags.NonPublic),
                 Save
             );
@@ -854,6 +859,9 @@ namespace BeaverBuddies
         }
     }
 
+    // the Time.time property getter is a Unity native-code builtin.
+    // stock Harmony doesn't support patching native code & neither does MonoMod.RuntimeDetours.
+    // this uses low-level MonoMod.Core directly.
     public class TimeTimePatcher {
         private static float time = 0;
 

--- a/BeaverBuddies/DeterminismService.cs
+++ b/BeaverBuddies/DeterminismService.cs
@@ -8,6 +8,8 @@ using BeaverBuddies.DesyncDetecter;
 using BeaverBuddies.IO;
 using Bindito.Core.Internal;
 using HarmonyLib;
+using Mono.Cecil.Cil;
+using MonoMod.Core.Platforms;
 using MonoMod.RuntimeDetour;
 using System;
 using System.Collections.Generic;
@@ -860,15 +862,22 @@ namespace BeaverBuddies
         }
 
         public static void Install() {
-            var hook = new Hook(
-                typeof(Time).GetProperty(nameof(Time.time)).GetGetMethod(),
-                GetTime
+            Debug.Log(typeof(Time).GetProperty(nameof(Time.time)).GetGetMethod().GetMethodBody());
+            Debug.Log(PlatformTriple.Current.SupportedFeatures.Has(ArchitectureFeature.CreateAltEntryPoint));
+
+            var original_method = typeof(Time).GetProperty(nameof(Time.time)).GetGetMethod();
+            var original_pointer = PlatformTriple.Current.GetNativeMethodBody(original_method);
+            PlatformTriple.Current.PinMethodIfNeeded(original_method);
+            var replacement_pointer = Marshal.GetFunctionPointerForDelegate(GetTime);
+
+            var detour = PlatformTriple.Current.CreateSimpleDetour(
+                original_pointer,
+                replacement_pointer
             );
         }
 
-        static float GetTime(Time __instance)
-        {
-            if (EventIO.IsNull) return Time.time;
+        static float GetTime() {
+            if (EventIO.IsNull) return 0;
             return time;
         }
     }

--- a/BeaverBuddies/DeterminismService.cs
+++ b/BeaverBuddies/DeterminismService.cs
@@ -880,11 +880,11 @@ namespace BeaverBuddies
             // it's capable of generate an alternate entrypoint to access the original native method.
             // however, native MacOS doesn't suppoert ArchitectureFeature.CreateAltEntryPoint.
             // therefore we have to recklessly overwrite & use a hack to make do, see below.
-            var detour = PlatformTriple.Current.CreateNativeDetour(
+            // again no need to clean up, this hook is intended to be permanent.
+            PlatformTriple.Current.CreateNativeDetour(
                 original_pointer,
                 replacement_pointer
             );
-            var backup_pointer = detour.AltEntry;
         }
 
         static float GetTime() {

--- a/BeaverBuddies/DeterminismService.cs
+++ b/BeaverBuddies/DeterminismService.cs
@@ -8,20 +8,14 @@ using BeaverBuddies.DesyncDetecter;
 using BeaverBuddies.IO;
 using Bindito.Core.Internal;
 using HarmonyLib;
-using Mono.Cecil.Cil;
 using MonoMod.Core.Platforms;
 using MonoMod.RuntimeDetour;
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.IO;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
-using Timberborn.Analytics;
 using Timberborn.Autosaving;
-using Timberborn.BaseComponentSystem;
 using Timberborn.Beavers;
 using Timberborn.BlueprintSystem;
 using Timberborn.BotUpkeep;
@@ -44,7 +38,6 @@ using Timberborn.StockpileVisualization;
 using Timberborn.TerrainSystemRendering;
 using Timberborn.TickSystem;
 using Timberborn.TimeSystem;
-using Timberborn.ToolSystem;
 using Timberborn.WalkingSystem;
 using Timberborn.WaterBuildings;
 using Timberborn.WorkshopsEffects;
@@ -52,7 +45,6 @@ using TimberNet;
 using UnityEngine;
 using static BeaverBuddies.SingletonManager;
 using static Timberborn.GameSaveRuntimeSystem.GameSaver;
-using static UnityEngine.UIElements.VisualNodePropertyRegistry;
 
 namespace BeaverBuddies
 {
@@ -700,12 +692,11 @@ namespace BeaverBuddies
     // see https://github.com/pardeike/Harmony/issues/563#issuecomment-1889259983.
     // this uses Hook from MonoMod.RuntimeDetours instead.
     public class GameSaverSavePatcher {
+        // Holding the (unused) hook reference keeps it active.
         private static Hook hook;
         public static bool IsSaving { get; set; }
 
         public static void Install() {
-            Debug.Log(typeof(System.Reflection.Emit.DynamicMethod).AssemblyQualifiedName);
-
             // holding a reference to the hook keeps it active.
             hook = new Hook(
                 typeof(GameSaver).GetMethod(nameof(GameSaver.Save), BindingFlags.Instance | BindingFlags.NonPublic),
@@ -718,12 +709,12 @@ namespace BeaverBuddies
                 original(instance, queuedSave);
                 return;
             }
-            TickingService ts = GetSingleton<TickingService>();
-            if (ts == null) {
+            ReplayService replayService = GetSingleton<ReplayService>();
+            if (replayService == null) {
                 original(instance, queuedSave);
                 return;
             }
-            ts.FinishFullTickAndThen(() =>
+            replayService.FinishFullTickIfNeededAndThen(() =>
             {
                 IsSaving = true;
                 original(instance, queuedSave);
@@ -864,10 +855,12 @@ namespace BeaverBuddies
     // stock Harmony doesn't support patching native code & neither does MonoMod.RuntimeDetours.
     // this uses low-level MonoMod.Core directly.
     public class TimeTimePatcher {
+        // Holding the (unused) detour reference keeps it active.
         private static SimpleNativeDetour detour;
         private static float time = 0;
 
-        public static void SetTicksSinceLoaded(int ticks) {
+        public static void SetTicksSinceLoaded(int ticks)
+        {
             time = ticks * Time.fixedDeltaTime;
         }
 

--- a/BeaverBuddies/Plugin.cs
+++ b/BeaverBuddies/Plugin.cs
@@ -119,6 +119,7 @@ namespace BeaverBuddies
 
             Harmony harmony = new Harmony(ID);
             harmony.PatchAll();
+            GameSaverSavePatcher.Install();
 
             Log(UnityEngine.Application.consoleLogPath);
         }

--- a/BeaverBuddies/Plugin.cs
+++ b/BeaverBuddies/Plugin.cs
@@ -120,6 +120,7 @@ namespace BeaverBuddies
             Harmony harmony = new Harmony(ID);
             harmony.PatchAll();
             GameSaverSavePatcher.Install();
+            TimeTimePatcher.Install();
 
             Log(UnityEngine.Application.consoleLogPath);
         }

--- a/BeaverBuddies/Plugin.cs
+++ b/BeaverBuddies/Plugin.cs
@@ -117,8 +117,11 @@ namespace BeaverBuddies
             
             Log($"{Name} v{Version} is loaded!");
 
+            // apply all harmony patches automatically.
             Harmony harmony = new Harmony(ID);
             harmony.PatchAll();
+
+            // apply each advanced monomod patch manually.
             GameSaverSavePatcher.Install();
             TimeTimePatcher.Install();
 

--- a/BeaverBuddies/env.props.unix-template
+++ b/BeaverBuddies/env.props.unix-template
@@ -1,14 +1,17 @@
 <Project>
 	<PropertyGroup>
-    <!-- Note: All paths should end in a slash -->
-    <!-- MSBuild accepts both forward slashes & backslashes -->
-		<!-- Should point to the installation directory of Timberborn -->
+    <!-- Note that all paths should end in a slash -->
+		<!-- Note that MSBuild accepts both forward slashes & backslashes -->
+		<!-- Point to the installation directory of Timberborn -->
 		<TimberbornDataPath>$(HOME)/Library/Application Support/Steam/steamapps/common/Timberborn/Timberborn.app/Contents/Resources/Data/</TimberbornDataPath>
-		<!-- Should point to the BepInEx directory -->
-		<BepInExPath>$(HOME)/dev/BepInEx/BepInEx/</BepInExPath>
-    <!-- Should point to the most recent version of the ModSettings mod libraries -->
-    <ModSettingsPath>$(HOME)/Documents/Timberborn/Mods/modsettings-ey0f/version-1.0/Scripts/</ModSettingsPath>
-		<!-- Should point to the Documents path, where Timberborn/Mods is located -->
+
+		<!-- Point to the Documents path, where Timberborn/Mods is located -->
 		<DocumentsPath>$(HOME)/Documents/</DocumentsPath>
+
+    <!-- Point to the most recent version of the Harmony mod library -->
+    <HarmonyPath>$(DocumentsPath)/Timberborn/Mods/Harmony_2.4.1/</HarmonyPath>
+
+    <!-- Point to the most recent version of the ModSettings mod libraries -->
+    <ModSettingsPath>$(DocumentsPath)/Timberborn/Mods/modsettings-ey0f/version-1.0/Scripts/</ModSettingsPath>
 	</PropertyGroup>
 </Project>

--- a/BeaverBuddies/env.props.windows-template
+++ b/BeaverBuddies/env.props.windows-template
@@ -1,14 +1,17 @@
 <Project>
 	<PropertyGroup>
-		<!-- Note: All paths should end in a slash -->
-		<!-- Should point to the installation directory of Timberborn -->
+    <!-- Note that all paths should end in a slash -->
+		<!-- Point to the installation directory of Timberborn -->
 		<TimberbornDataPath>C:\Program Files (x86)\Steam\steamapps\common\Timberborn\Timberborn_Data\</TimberbornDataPath>
-		<!-- Should point to the BepInEx directory -->
-		<BepInExPath>C:\Dev\BepInEx\</BepInExPath>
-		<!-- Should point to the most recent version of the ModSettings mod libraries -->
-		<ModSettingsPath>C:\Program Files (x86)\Steam\steamapps\workshop\content\1062090\3283831040\version-0.7\Scripts\</ModSettingsPath>
-		<!-- Should point to the Documents path, where Timberborn/Mods is located -->
+
+		<!-- Point to the Documents path, where Timberborn/Mods is located -->
 		<!-- Use the registry because the doc folder can be modified outside $(USERPROFILE) like E:\DocLibrary -->
 		<DocumentsPath>$(registry:HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders@Personal)\</DocumentsPath>
+
+    <!-- Point to the most recent version of the Harmony mod library -->
+    <HarmonyPath>$(DocumentsPath)\Timberborn\Mods\Harmony_2.4.1\</HarmonyPath>
+
+    <!-- Point to the most recent version of the ModSettings mod libraries -->
+    <ModSettingsPath>$(DocumentsPath)/Timberborn/Mods/modsettings-ey0f/version-1.0/Scripts/</ModSettingsPath>
 	</PropertyGroup>
 </Project>

--- a/BeaverBuddies/manifest.json
+++ b/BeaverBuddies/manifest.json
@@ -5,7 +5,7 @@
   "MinimumGameVersion": "1.0.0.0",
   "Description": "BeaverBuddies is a Timberborn mod that adds multiplayer co-op!",
   "RequiredMods": [
-		{ "Id": "Harmony" },
+    { "Id": "Harmony" },
     { "Id": "eMka.ModSettings", "MinimumVersion": "0.7.2.0" }
   ]
 }

--- a/BeaverBuddies/manifest.json
+++ b/BeaverBuddies/manifest.json
@@ -1,13 +1,11 @@
 {
   "Name": "BeaverBuddies - Multiplayer Co-Op",
-  "Version": "1.6.4",
+  "Version": "1.6.5",
   "Id": "beaverbuddies",
-  "MinimumGameVersion": "0.7.2.0",
+  "MinimumGameVersion": "1.0.0.0",
   "Description": "BeaverBuddies is a Timberborn mod that adds multiplayer co-op!",
   "RequiredMods": [
-    {
-      "Id": "eMka.ModSettings",
-      "MinimumVersion": "0.7.2.0"
-    }
+		{ "Id": "Harmony" },
+    { "Id": "eMka.ModSettings", "MinimumVersion": "0.7.2.0" }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ We appreciate your help! To get started working on BeaverBuddies, see [the guide
 ## How to Build BeaverBuddies
 
 1. Clone this repo `git clone git@github.com:thomaswp/BeaverBuddies`.
-2. Set up DotNet C#.
-   For Windows, download & install [Visual Studio community edition](https://visualstudio.microsoft.com/vs/community).
+2. Set up DotNet C#.  
+   For Windows, download & install [Visual Studio community edition](https://visualstudio.microsoft.com/vs/community).  
    For Mac, either run `brew install dotnet` or download & install [DotNet SDK](https://dotnet.microsoft.com/en-us/download).
-3. Build the project.
-   For Visual Studio, open the solution & hit Ctrl+Shift+B. For DotNet SDK, go to the BeaverBuddies directory & run `dotnet build`.
-   You may get a "directory not found" error. To fix this, open `BeaverBuddies/BeaverBuddies/env.props` and adjust the environmental variables to point to your Timberborn installation & the necessary mods.
+3. Build the project.  
+   For Visual Studio, open the solution & hit Ctrl+Shift+B.  
+   For DotNet SDK, go to the BeaverBuddies directory & run `dotnet build`.  
+   You may get a few "directory not found" errors. To fix these, open `BeaverBuddies/BeaverBuddies/env.props` and adjust the environmental variables there to point to your Timberborn installation & the necessary mods.
 
 Building on Linux is similar to on Mac.
 
@@ -32,5 +33,5 @@ Building on Linux is similar to on Mac.
 
 1. Make sure your project has been built with no errors.
 2. Confirm that the mod files were copied to your Timberborn mods folder (e.g. `Documents/Timberborn/Mods/BeaverBuddies`.
-3. Launch Timberborn and select the BeaverBuddies mod on the mod selection screen.
-   There may be multiple BeaverBuddies mod entries. The one with a "folder" icon next to it is the local build, select it.
+3. Launch Timberborn and select the BeaverBuddies mod on the mod selection screen.  
+   There may be multiple BeaverBuddies mod entries. The one with a "folder" icon next to it is your local build, select it.

--- a/README.md
+++ b/README.md
@@ -1,30 +1,36 @@
 # BeaverBuddies
 
+[![Last commit](https://img.shields.io/github/last-commit/thomaswp/BeaverBuddies?label=Last%20commit&color=lightgray)](https://github.com/thomaswp/BeaverBuddies/commits)
+[![License](https://img.shields.io/github/license/thomaswp/BeaverBuddies?label=License&color=gray)](https://github.com/thomaswp/BeaverBuddies/blob/master/License.txt)
+[![Timberborn 1.0](https://img.shields.io/badge/Timberborn_1.0-compatible-peru)](https://mechanistry.com)
+[![Discord mod thread](https://img.shields.io/badge/Discord-mod_thread-mediumpurple)](https://discord.com/channels/558398674389172225/1203786573142032445)  
+[![Steam Workshop](https://img.shields.io/badge/Steam_Workshop-available-royalblue)](https://steamcommunity.com/sharedfiles/filedetails/?id=3293380223)
+[![mod.io](https://img.shields.io/badge/mod.io-available-limegreen)](https://mod.io/g/timberborn/m/beaverbuddies)
+
 BeaverBuddies is a mod to allow multiplayer co-op in Timberborn.
 
-**If you would like to use the mod**, please see the documentation on the [wiki](https://github.com/thomaswp/BeaverBuddies/wiki)! This README is for develoeprs.
+> [!IMPORTANT]
+> **If you would like to use the BeaverBuddies mod**, please see [the setup instructions in the wiki](https://github.com/thomaswp/BeaverBuddies/wiki)! This README is for developers.
 
-## Setup
+## Contributing
 
-1. Install BepInEx, currently [this version](https://github.com/BepInEx/BepInEx/releases/tag/v5.4.22), by downloading the correct .zip folder, unzipping it, and putting the contents into your Timberborn game folder (likely something like `C:\Program Files (x86)\Steam\steamapps\common\Timberborn` on Windows). You should have a folder structure with something like `Timberborn\BepInEx\plugins\`.
-2. Run Timberborn to finish installing BepInEx. If it was successful, you should have a `config` folder inside of your `BepInEx` folder.
-  * Suggested: update `Timberborn\BepInEx\config\BepInEx.cfg` as follows to include console output:
-```
-[Logging.Console]
+We appreciate your help! To get started working on BeaverBuddies, see [the guide in the wiki](https://github.com/thomaswp/BeaverBuddies/wiki/Contributing).
 
-## Enables showing a console for log output.
-# Setting type: Boolean
-# Default value: false
-Enabled = true # Change this to true
-```
-3. Install [Visual Studio 2022 community edition](https://visualstudio.microsoft.com/downloads/) and open this solution with it.
-4. Build and run the project (Ctrl+shift+B). You may get errors about missing dependencies. To fix them, open `BeaverBuddies/BeaverBuddies/env.props` and adjust the environmental variables as needed.
-   * `env.props` should have been created automatically, but if not you can copy `env.props.template` to `env.props`.
-   * 
+## How to Build BeaverBuddies
 
-## Running the Mod
+1. Clone this repo `git clone git@github.com:thomaswp/BeaverBuddies`.
+2. Set up DotNet C#.
+   For Windows, download & install [Visual Studio community edition](https://visualstudio.microsoft.com/vs/community).
+   For Mac, either run `brew install dotnet` or download & install [DotNet SDK](https://dotnet.microsoft.com/en-us/download).
+3. Build the project.
+   For Visual Studio, open the solution & hit Ctrl+Shift+B. For DotNet SDK, go to the BeaverBuddies directory & run `dotnet build`.
+   You may get a "directory not found" error. To fix this, open `BeaverBuddies/BeaverBuddies/env.props` and adjust the environmental variables to point to your Timberborn installation & the necessary mods.
 
-1. Make sure your project has been built with no errors. 
-2. Confirm that the mod files were copied to your Timberborn mods folder (e.g. `Documets/Timberborn/Mods/BeaverBuddies`
+Building on Linux is similar to on Mac.
+
+## How to Test Your Build
+
+1. Make sure your project has been built with no errors.
+2. Confirm that the mod files were copied to your Timberborn mods folder (e.g. `Documents/Timberborn/Mods/BeaverBuddies`.
 3. Launch Timberborn and select the BeaverBuddies mod on the mod selection screen.
-
+   There may be multiple BeaverBuddies mod entries. The one with a "folder" icon next to it is the local build, select it.


### PR DESCRIPTION
This adjusts BeaverBuddies to depend on the [stock Harmony mod](https://github.com/eMkaQQ/timberborn-harmony) instead of bundling HarmonyX.

The change is straightforward for all but [two patches](https://github.com/thomaswp/BeaverBuddies/issues/25#issuecomment-2255863993):
1. For `GameSaver.Save`, stock Harmony is unable to patch a method whose [original includes a try-catch-when](https://github.com/pardeike/Harmony/issues/563#issuecomment-1889259983) block. This method's original does so we use `MonoMod.RuntimeDetours`'s `Hook`.

2. For `Time.time`, this one's a Unity built-in so can't be patched with Harmony or hooked with `MonoMod.RuntimeDetour`. Instead we use `MonoMod.Core`'s `CreateSimpleDetour`.

A checklist before this is ready to merge looks something like the following:
- [x] clean up the code a bit & deal with the MacOS native entrypoint problem;
- [x] add better comments;
- [x] world-load-test the build, as opposed to only game-load-testing it;
- [x] multiplayer-test the build; &
- [x] test the build on Windows.

When finished this will resolve #101.

Note that this is introduces a new dependency for BeaverBuddies & is an unavoidable breaking change for the `env.props` file format, replacing `BepInExPath` with `HarmonyPath`.