### PR TITLE
steam overlay crash fix

### DIFF
--- a/BeaverBuddies/Connect/ClientConnectionService.cs
+++ b/BeaverBuddies/Connect/ClientConnectionService.cs
@@ -96,7 +96,7 @@ namespace BeaverBuddies.Connect
             {
                 ShowError("BeaverBuddies.JoinCoopGame.Error.CouldNotConnect", error);
             });
-            
+
             if (client == null)
             {
                 Plugin.Log("Client creation failed.");

--- a/BeaverBuddies/Steam/SteamOverlayInputBlockerPatch.cs
+++ b/BeaverBuddies/Steam/SteamOverlayInputBlockerPatch.cs
@@ -1,0 +1,32 @@
+#define IS_STEAM
+
+#if IS_STEAM
+using HarmonyLib;
+using System;
+using Timberborn.CoreUI;
+using UnityEngine;
+
+namespace BeaverBuddies.Steam
+{
+    /// <summary>
+    /// Patches SteamOverlayInputBlocker to suppress exceptions when dialogs are shown on top.
+    /// Without this, showing a dialog while overlay is active causes a crash when overlay closes.
+    /// </summary>
+    [HarmonyPatch(typeof(Timberborn.SteamOverlaySystem.SteamOverlayInputBlocker), "SteamOverlayActivated")]
+    public class SteamOverlayInputBlockerPatch
+    {
+        static Exception Finalizer(Exception __exception)
+        {
+            // Suppress the "not on top of the stack" exception
+            // This happens when we show our connection dialog while overlay is open
+            if (__exception != null && __exception is ArgumentException &&
+                __exception.Message.Contains("is not on top of the stack"))
+            {
+                Debug.Log("BeaverBuddies: Suppressed SteamOverlayInputBlocker stack exception (expected when showing dialogs during overlay)");
+                return null; // Suppress the exception
+            }
+            return __exception;
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Fixes https://github.com/thomaswp/BeaverBuddies/issues/126

When accepting a Steam lobby invite through the Steam overlay, the mod attempted to show a connection dialog immediately. However, the Steam overlay was in the process of closing and had a `SteamOverlayInputBlocker` panel on Timberborn's panel stack. Trying to push a new dialog onto the stack while the overlay was closing caused an ArgumentException: "IPanelController SteamOverlayInputBlocker is not on top of the stack!"

Solution:
Add a very short delay after the lobby join. This gives the Steam overlay enough time to fully close and clean up its input blocker from the panel stack before our dialog is shown. The implementation uses a simple frame counter that decrements in `UpdateSingleton()`