### PR TITLE
Support building with latest DotNet

### DIFF
--- a/BeaverBuddies/BeaverBuddies.csproj
+++ b/BeaverBuddies/BeaverBuddies.csproj
@@ -30,6 +30,7 @@
     <!-- Include HarmonyX file inside $(BeaverBuddiesModsPath) -->
     <includeHarmonyX>true</includeHarmonyX>
     <NuGetPackagesDir>$(UserProfile)\.nuget\packages\</NuGetPackagesDir>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <Target Name="CheckEnv" BeforeTargets="BeforeBuild">

--- a/ClientServerSimulator/ClientServerSimulator.csproj
+++ b/ClientServerSimulator/ClientServerSimulator.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Inspector/Inspector.csproj
+++ b/Inspector/Inspector.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TimberNet/TimberNet.csproj
+++ b/TimberNet/TimberNet.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <Nullable>enable</Nullable>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
DotNet 10 requires Windows targeting to be explicit. With this new config property BeaverBuddies can be built using the latest DotNet. The new property will be ignored by older versions of the compiler.

This makes the development setup instructions simpler. We'll no longer need to require contributors to install a specific version of DotNet.