### PR TITLE
Feature/steam overlay fix

### DIFF
--- a/BeaverBuddies/Steam/SteamOverlayConnectionService.cs
+++ b/BeaverBuddies/Steam/SteamOverlayConnectionService.cs
@@ -11,6 +11,10 @@ using System.Collections.Generic;
 using System.Text;
 using Timberborn.SingletonSystem;
 using UnityEngine;
+using Timberborn.SteamOverlaySystem;
+using Timberborn.CoreUI;
+using JetBrains.Annotations;
+using UnityEngine.UIElements;
 
 namespace BeaverBuddies.Steam
 {
@@ -21,16 +25,27 @@ namespace BeaverBuddies.Steam
 #if IS_STEAM
         private SteamManager _steamManager;
         private ClientConnectionService _clientConnectionService;
+        private PanelStack _panelStack;
+        private SteamOverlayInputBlocker _inputBlocker;
+        private EventBus _eventBus;
+
+        private bool? _lastSuccess = null;
 
         private static List<IDisposable> callbacks = new List<IDisposable>();
 
         public SteamOverlayConnectionService(
             SteamManager steamManager,
-            ClientConnectionService clientConnectionService
+            ClientConnectionService clientConnectionService,
+            SteamOverlayInputBlocker steamOverlayInputBlocker,
+            PanelStack panelStack,
+            EventBus eventBus
             )
         {
             _steamManager = steamManager;
             _clientConnectionService = clientConnectionService;
+            _panelStack = panelStack;
+            _inputBlocker = steamOverlayInputBlocker;
+            _eventBus = eventBus;
         }
 
         bool done = false;
@@ -104,14 +119,48 @@ namespace BeaverBuddies.Steam
             SteamNetworking.AcceptP2PSessionWithUser(clientId);
         }
 
+        // This should only be called if the SteamOverlayInputBlocker is on top,
+        // so we can assume it was the panel that was just removed.
+        // TODO: Check if this gets called if the game starts loading and clears the stack...
+        // If so, we need to check for that here before showing the pop-up
+        [OnEvent]
+        public void OnPanelHidden(PanelHiddenEvent panelHiddenEvent)
+        {
+            if (!_lastSuccess.HasValue) return;
+            _clientConnectionService.ShowConnectionMessage(_lastSuccess.Value);
+            ClearWaitForSteamOverlay();
+        }
+
+        private void WaitForSteamOverlayToClose(bool success)
+        {
+            _lastSuccess = success;
+            _eventBus.Register(this);
+        }
+
+        private void ClearWaitForSteamOverlay()
+        {
+            _lastSuccess = null;
+            _eventBus.Unregister(this);
+
+        }
+
+
         private void OnLobbyEntered(LobbyEnter_t callback)
         {
+            ClearWaitForSteamOverlay();
             var owner = SteamMatchmaking.GetLobbyOwner(new CSteamID(callback.m_ulSteamIDLobby));
             if (owner != SteamUser.GetSteamID())
             {
                 Plugin.Log("Joining another's lobby...");
                 bool success = _clientConnectionService.TryToConnect(owner);
-                _clientConnectionService.ShowConnectionMessage(success);
+                if (_panelStack.IsPanelOnTop(_inputBlocker))
+                {
+                    WaitForSteamOverlayToClose(success);
+                }
+                else
+                {
+                    _clientConnectionService.ShowConnectionMessage(success);
+                }
             }
         }
 #else

--- a/BeaverBuddies/Steam/SteamOverlayConnectionService.cs
+++ b/BeaverBuddies/Steam/SteamOverlayConnectionService.cs
@@ -121,8 +121,8 @@ namespace BeaverBuddies.Steam
 
         // This should only be called if the SteamOverlayInputBlocker is on top,
         // so we can assume it was the panel that was just removed.
-        // TODO: Check if this gets called if the game starts loading and clears the stack...
-        // If so, we need to check for that here before showing the pop-up
+        // If the game starts, it clears the stack silently, so this isn't shown
+        // (also this Singleton is disposed when the current scene ends).
         [OnEvent]
         public void OnPanelHidden(PanelHiddenEvent panelHiddenEvent)
         {

--- a/BeaverBuddies/Steam/SteamOverlayInputBlockerPatch.cs
+++ b/BeaverBuddies/Steam/SteamOverlayInputBlockerPatch.cs
@@ -1,0 +1,30 @@
+﻿using HarmonyLib;
+using Steamworks;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Timberborn.SteamOverlaySystem;
+using Timberborn.SteamStoreSystem;
+
+namespace BeaverBuddies.Steam
+{
+    [HarmonyPatch(typeof(SteamOverlayInputBlocker), nameof(SteamOverlayInputBlocker.SteamOverlayActivated))]
+    internal class SteamOverlayInputBlockerPatch
+    {
+        static bool Prefix(SteamOverlayInputBlocker __instance, GameOverlayActivated_t callback)
+        {
+            // If closing the UI and we'd normally pop the panel...
+            if (callback.m_nAppID == SteamAppId.AppId && callback.m_bActive != 1)
+            {
+                // If the stack is empty (e.g. because we've loaded a map and the stack was cleared),
+                // stop the base method from running.
+                var stack = __instance._panelStack._stack;
+                if (stack.Count == 0)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ Enabled = true # Change this to true
 1. Make sure your project has been built with no errors. 
 2. Confirm that the mod files were copied to your Timberborn mods folder (e.g. `Documets/Timberborn/Mods/BeaverBuddies`
 3. Launch Timberborn and select the BeaverBuddies mod on the mod selection screen.
+

--- a/README.md
+++ b/README.md
@@ -27,4 +27,3 @@ Enabled = true # Change this to true
 1. Make sure your project has been built with no errors. 
 2. Confirm that the mod files were copied to your Timberborn mods folder (e.g. `Documets/Timberborn/Mods/BeaverBuddies`
 3. Launch Timberborn and select the BeaverBuddies mod on the mod selection screen.
-


### PR DESCRIPTION
Implements @robinplace's suggested fix for this from #129. Also adds a safety measure to prevent the game crashing if the overlay is removed after the map is loaded and the panel stack is cleared. 

I also need to test what happens if the overlay is closed after loading starts. Does the event listener get destroyed? Does the panel removed event happen?

This isn't yet tested (I'll need two computers for that).