### PR TITLE
fix randomness with initial beaver naming

### DIFF
--- a/BeaverBuddies/DeterminismService.cs
+++ b/BeaverBuddies/DeterminismService.cs
@@ -17,6 +17,7 @@ using Timberborn.Analytics;
 using Timberborn.Autosaving;
 using Timberborn.BaseComponentSystem;
 using Timberborn.Beavers;
+using Timberborn.BeaverPopulation;
 using Timberborn.BlueprintSystem;
 using Timberborn.BotUpkeep;
 using Timberborn.Brushes;
@@ -125,6 +126,7 @@ namespace BeaverBuddies
         public static bool IsNonGameplay = false;
         private static System.Random random = new System.Random();
         private static HashSet<Type> activeNonGamePatchers = new HashSet<Type>();
+        private static HashSet<Type> activeGamePatchers = new HashSet<Type>();
         private static int? nextSeedOnLoad;
 
         public void Reset()
@@ -132,6 +134,7 @@ namespace BeaverBuddies
             IsNonGameplay = false;
             IsTicking = false;
             activeNonGamePatchers.Clear();
+            activeGamePatchers.Clear();
             // No need to reset random
             // Don't reset seed, since it's set before the Reset
         }
@@ -207,6 +210,9 @@ namespace BeaverBuddies
                     return true;
                 }
 
+                // If this is explicitly marked as game code, use game RNG
+                if (activeGamePatchers.Count > 0) return false;
+
                 bool areActiveNonGamePatchers = activeNonGamePatchers.Count > 0;
 
                 // If this is non-game code, don't use the Game's random
@@ -267,6 +273,18 @@ namespace BeaverBuddies
             else
             {
                 return activeNonGamePatchers.Remove(patcherType);
+            }
+        }
+
+        public static bool SetGamePatcherActive(System.Type patcherType, bool active)
+        {
+            if (active)
+            {
+                return activeGamePatchers.Add(patcherType);
+            }
+            else
+            {
+                return activeGamePatchers.Remove(patcherType);
             }
         }
 
@@ -565,6 +583,23 @@ namespace BeaverBuddies
         static void Postfix()
         {
             DeterminismService.SetNonGamePatcherActive(typeof(DateSalterPatcher), false);
+        }
+    }
+
+    // BeaverNameService.RandomName uses RNG to pick beaver names. This can happen
+    // outside of a tick (during entity initialization via Unity's Start()), but it needs
+    // to be deterministic for consistency.
+    [HarmonyPatch(typeof(BeaverNameService), nameof(BeaverNameService.RandomName))]
+    public class BeaverNameServiceRandomNamePatcher
+    {
+        static void Prefix()
+        {
+            DeterminismService.SetGamePatcherActive(typeof(BeaverNameServiceRandomNamePatcher), true);
+        }
+
+        static void Postfix()
+        {
+            DeterminismService.SetGamePatcherActive(typeof(BeaverNameServiceRandomNamePatcher), false);
         }
     }
 


### PR DESCRIPTION
The people I play with care about this sort of stuff and noticed that beaver names do not currently match on birth

Having looked through the logs, I found the following warning

```
[16-51-14.18] Unknown random called outside of tick
  at BeaverBuddies.Plugin.LogStackTrace () [0x00000] in <74dbf2d5fb3b47f4a28cf4963b2c4b53>:0 
  at BeaverBuddies.DeterminismService.LogUnknownRandomCalled () [0x00000] in <74dbf2d5fb3b47f4a28cf4963b2c4b53>:0 
  at BeaverBuddies.DeterminismService.get_ShouldFreezeSeed () [0x00000] in <74dbf2d5fb3b47f4a28cf4963b2c4b53>:0 
  at BeaverBuddies.DeterminismService.ShouldUseNonGameRNG () [0x00000] in <74dbf2d5fb3b47f4a28cf4963b2c4b53>:0 
  at BeaverBuddies.RandomRangeIntPatcher.Prefix (System.Int32 inclusiveMin, System.Int32 exclusiveMax, System.Int32& __result) [0x00000] in <74dbf2d5fb3b47f4a28cf4963b2c4b53>:0 
  at MonoMod.Utils.DynamicMethodDefinition.Timberborn.Common.RandomNumberGenerator.Range_Patch1 (Timberborn.Common.RandomNumberGenerator , System.Int32 , System.Int32 ) [0x00000] in <c885cb095a2f4b47beab934d510aafd0>:0 
  at Timberborn.Common.RandomNumberGenerator.GetListElement[T] (System.Collections.Generic.IReadOnlyList`1[T] list) [0x00000] in <ed85ad547402424491d24b7d34a5fea1>:0 
  at Timberborn.Beavers.BeaverNameService.RandomName () [0x00000] in <93e526e1b383495aaae23dbda06965e8>:0 
  at Timberborn.Beavers.BeaverEntityNamer.GenerateEntityName () [0x00000] in <93e526e1b383495aaae23dbda06965e8>:0 
  at Timberborn.EntityNaming.NamedEntity.InitializeEntity () [0x00000] in <3a6b871511cc4bf3afabe25c65a54a66>:0 
  at Timberborn.EntitySystem.EntityComponent.Initialize () [0x00000] in <ec6e914ba85f406bb6988b3d43ea3906>:0 
  at Timberborn.EntitySystem.EntityComponent.InitializeIfUninitialized () [0x00000] in <ec6e914ba85f406bb6988b3d43ea3906>:0 
  at Timberborn.EntitySystem.EntityComponent.Start () [0x00000] in <ec6e914ba85f406bb6988b3d43ea3906>:0 
  at Timberborn.BaseComponentSystem.BaseComponentUnityAdapter.Start () [0x00000] in <57612b8fcdda4088b0e6a35ba9e6883f>:0 
```

This change fixes that