### PR TITLE
simplify replay logic

### DIFF
--- a/BeaverBuddies/Events/ReplayEvent.cs
+++ b/BeaverBuddies/Events/ReplayEvent.cs
@@ -113,15 +113,13 @@ namespace BeaverBuddies.Events
         /// <returns>True if the method should use default behavior</returns>
         public static bool DoPrefix(Func<ReplayEvent> getEvent)
         {
+            // If we're already replaying events, just let the original method run.
+            // This handles nested calls (e.g., Replay() calls Unlock() which triggers this prefix again)
+            if (ReplayService.IsReplayingEvents) return true;
+
             // If the replay service is not available, just use default behavior
             ReplayService replayService = GetReplayServiceIfReady();
             if (replayService == null) return true;
-
-            // TODO: I don't think there's any reason to
-            // create the event here when replaying events, since
-            // it'll just get thrown away. Probably not a big deal, but
-            // it can be confusing in debugging. Too afraid it'll break
-            // something to change it right now though.
 
             // Get the event and if it's null, just use default behavior
             ReplayEvent message = getEvent();


### PR DESCRIPTION
Addresses https://github.com/thomaswp/BeaverBuddies/issues/116

When replaying events (e.g., `BuildingUnlockedEvent`), the `Replay()` method calls game methods like `BuildingUnlockingService.Unlock()`. These methods have Harmony prefixes that call `DoPrefix()`, which would go through the full logic of creating an event and checking EventIO.ShouldPlayPatchedEvents.

Although `ShouldPlayPatchedEvents` checks `IsReplayingEvents`, it did so after creating the event object. In some edge cases, this caused the nested call to return false, preventing the actual unlock from happening - the event was received and logged, but the game method never executed.

The fix adds an early return at the start of `DoPrefix()`: if we're already replaying events, immediately return true to let the original method run. This ensures nested calls during replay execute normally without going through unnecessary event creation/recording logic.