### PR TITLE
fix: desync fixes and lightweight RNG resync for v1.7.0

### DIFF
--- a/BeaverBuddies/BeaverBuddies.csproj
+++ b/BeaverBuddies/BeaverBuddies.csproj
@@ -17,7 +17,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>BeaverBuddies</AssemblyName>
     <Description>TimberModTest</Description>
-    <Version>1.6.6</Version>
+    <Version>1.7.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>

--- a/BeaverBuddies/DeterminismService.cs
+++ b/BeaverBuddies/DeterminismService.cs
@@ -1,7 +1,8 @@
 ﻿// If defined, parallel actions occur on the main thread
-// Disabled: the game's parallelizer is too tightly integrated in v1.0.12
-// to safely override. The parallel singletons (water, soil) should still
-// be deterministic as they write to separate buffers.
+// The parallel simulation (water, soil) is non-deterministic between
+// different machines, but enabling this may cause issues with the game's
+// internal state. Disabled for now; desync is handled via lightweight
+// RNG resync instead.
 //#define NO_PARALLEL
 // If defined, the game will use constant values instead of random
 // numbers, making it as deterministic as possible w.r.t random

--- a/BeaverBuddies/DeterminismService.cs
+++ b/BeaverBuddies/DeterminismService.cs
@@ -47,6 +47,7 @@ using Timberborn.WaterBuildings;
 using Timberborn.CharacterModelSystem;
 using Timberborn.DeconstructionSystem;
 using Timberborn.Healthcare;
+using Timberborn.NaturalResourcesContamination;
 using Timberborn.NaturalResourcesMoisture;
 using Timberborn.SlotSystem;
 using Timberborn.Wandering;
@@ -696,6 +697,35 @@ namespace BeaverBuddies
             if (EventIO.IsNull) return true;
             // Use fixed multiplier instead of random 0.9-1.1 range
             __result = __instance._wateredNaturalResourceSpec.DaysToDieDry;
+            return false;
+        }
+    }
+
+    // Fix for flooding desync: LivingWaterNaturalResource.GenerateRandomDaysToDie uses
+    // non-deterministic random (0.9-1.1 multiplier) when plants are submerged/flooded.
+    // Same pattern as WateredNaturalResource above.
+    [HarmonyPatch(typeof(LivingWaterNaturalResource), nameof(LivingWaterNaturalResource.GenerateRandomDaysToDie))]
+    class LivingWaterNaturalResourceGenerateRandomDaysToDiePatcher
+    {
+        static bool Prefix(LivingWaterNaturalResource __instance, ref float __result)
+        {
+            if (EventIO.IsNull) return true;
+            __result = __instance._floodableNaturalResourceSpec.DaysToDie;
+            return false;
+        }
+    }
+
+    // Fix for contamination desync: ContaminatedNaturalResource.GetDaysToDie uses
+    // non-deterministic random (Range(0.2, 0.3)) when natural resources get contaminated
+    // by badtide water. Replace with the midpoint value.
+    [HarmonyPatch(typeof(ContaminatedNaturalResource), nameof(ContaminatedNaturalResource.GetDaysToDie))]
+    class ContaminatedNaturalResourceGetDaysToDiePatcher
+    {
+        static bool Prefix(ref float __result)
+        {
+            if (EventIO.IsNull) return true;
+            // Use midpoint of MinDaysToDie (0.2) and MaxDaysToDie (0.3)
+            __result = 0.25f;
             return false;
         }
     }

--- a/BeaverBuddies/DeterminismService.cs
+++ b/BeaverBuddies/DeterminismService.cs
@@ -1,4 +1,7 @@
 ﻿// If defined, parallel actions occur on the main thread
+// Disabled: the game's parallelizer is too tightly integrated in v1.0.12
+// to safely override. The parallel singletons (water, soil) should still
+// be deterministic as they write to separate buffers.
 //#define NO_PARALLEL
 // If defined, the game will use constant values instead of random
 // numbers, making it as deterministic as possible w.r.t random
@@ -41,6 +44,12 @@ using Timberborn.TimeSystem;
 using Timberborn.ToolSystem;
 using Timberborn.WalkingSystem;
 using Timberborn.WaterBuildings;
+using Timberborn.CharacterModelSystem;
+using Timberborn.DeconstructionSystem;
+using Timberborn.Healthcare;
+using Timberborn.NaturalResourcesMoisture;
+using Timberborn.SlotSystem;
+using Timberborn.Wandering;
 using Timberborn.WorkshopsEffects;
 using TimberNet;
 using UnityEngine;
@@ -463,6 +472,15 @@ namespace BeaverBuddies
             typeof(TerrainBlockRandomizer),
             typeof(ObservatoryAnimator),
             typeof(WaterInputPipeSegmentCreator),
+            // New in game v1.0.12 - visual/non-gameplay classes that use RNG
+            typeof(CharacterTextureSetter),
+            typeof(DeconstructionParticleFactory),
+            typeof(BeaverInjuryTextureSetter),
+            typeof(VariedIdleAnimation),
+            // Pile is a nested class in GoodPileVariantsService (already blacklisted)
+            typeof(PatrollingSlot),
+            typeof(TransformSlot),
+            typeof(SlotAnimationSynchronizer),
         };
 
         // Currently unused - could be used for warnings on items we don't
@@ -990,14 +1008,21 @@ namespace BeaverBuddies
         static bool Prefix(TickableSingletonService __instance)
         {
             if (EventIO.IsNull) return true;
-            ImmutableArray<IParallelTickableSingleton>.Enumerator enumerator = 
+            // Reproduce the original method's setup, but run sequentially
+            // instead of via the thread pool for determinism
+            __instance.ParalleTicklIsFinished = false;
+            __instance.IsStartingParallelTick = true;
+            __instance._parallelizer.StartScheduling();
+            ImmutableArray<IParallelTickableSingleton>.Enumerator enumerator =
                 __instance._parallelTickableSingletons.GetEnumerator();
             while (enumerator.MoveNext())
             {
                 // Run directly rather than using the thread pool
                 IParallelTickableSingleton parallelTickable = enumerator.Current;
-                parallelTickable.ParallelTick();
+                parallelTickable.StartParallelTick();
             }
+            __instance._parallelizer.StopScheduling();
+            __instance.IsStartingParallelTick = false;
             return false;
         }
     }

--- a/BeaverBuddies/DeterminismService.cs
+++ b/BeaverBuddies/DeterminismService.cs
@@ -685,6 +685,21 @@ namespace BeaverBuddies
         }
     }
 
+    // Fix for issue #158: GenerateRandomDaysToDry uses non-deterministic random
+    // that causes desync when plants/trees dry out after being flooded.
+    // Replace the random multiplier (0.9-1.1) with a fixed value (1.0).
+    [HarmonyPatch(typeof(WateredNaturalResource), nameof(WateredNaturalResource.GenerateRandomDaysToDry))]
+    class WateredNaturalResourceGenerateRandomDaysToDryPatcher
+    {
+        static bool Prefix(WateredNaturalResource __instance, ref float __result)
+        {
+            if (EventIO.IsNull) return true;
+            // Use fixed multiplier instead of random 0.9-1.1 range
+            __result = __instance._wateredNaturalResourceSpec.DaysToDieDry;
+            return false;
+        }
+    }
+
     // This was removed when the method was removed: may need to revisit
     // Sometimes tool descriptions need an instance of the object they describe to describe it
     // and when it activates this can use randomness (e.g. WateredNaturalResource), which should

--- a/BeaverBuddies/Doc/ClassesWithRandom.txt
+++ b/BeaverBuddies/Doc/ClassesWithRandom.txt
@@ -1,61 +1,138 @@
-﻿= Fully addressed
-# Verified game logic or irrelevant
+= Fully addressed (blacklisted or patched)
+# Verified game logic - runs during tick, deterministic
 > At least partially addressed
 ~ Needs investigation
 + Unaddressed concern
 
+Last updated: 2026-04-05 for game v1.0.12.6
+
+=== Gameplay classes (run during ticks, use game RNG deterministically) ===
 # Timberborn.BeaverContaminationSystem.ContaminationApplier
   * In Tick
+# Timberborn.Beavers.BeaverLongevity
+  * In Tick (longevity calculation)
 # Timberborn.Beavers.BeaverNameService
-  * In RandomName
-> Timberborn.Beavers.BeaverTextureSetter
-Timberborn.BeaversUI.BeaverGeneratorTool
-> Timberborn.BotUpkeep.BotManufactoryAnimationController
+  * In RandomName - called from EntityComponent.Start() outside tick
+  * Intercepted by ShouldUseNonGameRNG() default case -> uses non-game RNG
+# Timberborn.HazardousWeatherSystem.BadtideWeather
+  * In Tick (weather cycle)
+# Timberborn.HazardousWeatherSystem.DroughtWeather
+  * In Tick (weather cycle)
+# Timberborn.HazardousWeatherSystem.HazardousWeatherRandomizer
+  * In Tick (weather randomization)
+# Timberborn.MortalSystem.CharacterKiller
+  * In Tick
+# Timberborn.MortalSystem.Mortal
+  * In Tick
+# Timberborn.NaturalResources.CoordinatesOffseter
+  * In Tick (resource positioning)
+# Timberborn.NaturalResourcesContamination.ContaminatedNaturalResource
+  * In Tick
+# Timberborn.NaturalResourcesMoisture.LivingWaterNaturalResource
+  * In Tick/Awake - Awake addressed via map hash seed
+# Timberborn.NaturalResourcesMoisture.WateredNaturalResource
+  * In Tick/Awake - Awake addressed via map hash seed
+# Timberborn.NaturalResourcesReproduction.NaturalResourceReproducer
+  * In Tick
+# Timberborn.Navigation.DistrictRandomDestinationPicker
+  * In Tick (renamed from DistrictDestinationPicker in v1.0.12)
+# Timberborn.NeedApplication.EffectProbabilityService
+  * In Tick
+# Timberborn.NeedApplication.WorkshopRandomNeedApplier
+  * In Tick
+# Timberborn.Pollination.Hive
+  * In Tick
+# Timberborn.Reproduction.ProcreationHouse
+  * In Tick
+# Timberborn.SleepSystem.Sleeper
+  * In Tick
+# Timberborn.Terraforming.Drill
+  * In Tick
+# Timberborn.WalkingSystem.RandomDestinationPicker
+  * In Tick
+# Timberborn.Wandering.StrandedRootBehavior
+  * In Tick
+# Timberborn.Wandering.WanderRootBehavior
+  * In Tick
+# Timberborn.WeatherSystem.TemperateWeatherDurationService
+  * In Tick (weather duration)
+# Timberborn.WindSystem.WindService
+  * In Tick
+# Timberborn.Yielding.YieldRemovalChanceBonusService
+  * In Tick
+
+=== Visual/Non-gameplay classes (blacklisted -> use NonTickRNG) ===
+= Timberborn.Beavers.BeaverTextureSetter
+= Timberborn.BotsUpkeep.BotManufactoryAnimationController
 = Timberborn.Brushes.BrushProbabilityMap
+= Timberborn.CharacterModelSystem.CharacterTextureSetter
+  * NEW in v1.0.12 - added to blacklist
 = Timberborn.CoreSound.BasicSelectionSound
+= Timberborn.DeconstructionSystem.DeconstructionParticleFactory
+  * NEW in v1.0.12 - added to blacklist
 = Timberborn.ForestryEffects.TreeCutterSideRandomizer
+  * Whitelisted - only runs during tick
 = Timberborn.ForestryEffects.TreeShaker
+  * Visual only
 = Timberborn.GameScene.DateSalter
+= Timberborn.GameSceneLoading.GameSceneLoader
+  * GetTip() uses RNG for loading tips - outside tick, intercepted
 = Timberborn.GameSound.GameMusicPlayer
-Timberborn.HazardousWeatherSystem.BadtideWeather
-Timberborn.HazardousWeatherSystem.DroughtWeather
-Timberborn.HazardousWeatherSystem.HazardousWeatherRandomizer
-~ Timberborn.Healthcare.BeaverInjuryTextureSetter
-Timberborn.MortalSystem.CharacterKiller
-Timberborn.MortalSystem.Mortal
-Timberborn.NaturalResources.CoordinatesOffseter
-Timberborn.NaturalResourcesContamination.ContaminatedNaturalResource
-~ Timberborn.NaturalResourcesModelSystem.NaturalResourceModelRandomizer
-Timberborn.NaturalResourcesMoisture.LivingWaterNaturalResource
-Timberborn.NaturalResourcesMoisture.WateredNaturalResource
-Timberborn.NaturalResourcesReproduction.NaturalResourceReproducer
-Timberborn.Navigation.DistrictDestinationPicker
-Timberborn.NeedApplication.EffectProbabilityService
-Timberborn.NeedApplication.WorkshopRandomNeedApplier
-Timberborn.Pollination.Hive
-Timberborn.RecoveredGoodSystem.RecoveredGoodStackCoordinatesFinder
-> Timberborn.RecoveredGoodSystem.RecoveredGoodStackFactory
-Timberborn.Reproduction.ProcreationHouse
-~ Timberborn.Ruins.RuinModelFactory
-~ Timberborn.Ruins.RuinModelUpdater
-Timberborn.SleepSystem.Sleeper
-Timberborn.SlotSystem.PatrollingSlotFactory
-Timberborn.SlotSystem.SlotAnimationSynchronizer
-Timberborn.SlotSystem.SlotManager
-Timberborn.SlotSystem.TransformSlotFactory
-> Timberborn.SoundSystem.LoopingSoundPlayer
-> Timberborn.SoundSystem.Sounds
-~ Timberborn.StockpileVisualization.GoodColumnVariantsService
-~ Timberborn.StockpileVisualization.GoodPileVariantsService
-> Timberborn.StockpileVisualization.StockpileGoodPileVisualizer
-Timberborn.Terraforming.Drill
-> Timberborn.TerrainSystem.TerrainBlockRandomizer
-Timberborn.WalkingSystem.RandomDestinationPicker
-Timberborn.Wandering.StrandedRootBehavior
-Timberborn.Wandering.WanderRootBehavior
-+ Timberborn.WaterBuildings.WaterInputPipeSegmentFactory
-Timberborn.WeatherSystem.TemperateWeatherDurationService
-Timberborn.WindSystem.WindService
-~ Timberborn.WorkshopsEffects.ObservatoryAnimator
-  * Cannot currently address because of outdated library
-Timberborn.Yielding.YieldRemovalChanceBonusService
+= Timberborn.Healthcare.BeaverInjuryTextureSetter
+  * NEW in v1.0.12 - added to blacklist
+= Timberborn.NaturalResourcesModelSystem.NaturalResourceModelRandomizer
+= Timberborn.RecoveredGoodSystem.RecoveredGoodStackCoordinatesFinder
+  * Visual positioning
+= Timberborn.RecoveredGoodSystem.RecoveredGoodStackFactory
+  * Patched via SetNonGamePatcherActive for RandomizeRotation
+= Timberborn.Ruins.RuinModelFactory
+= Timberborn.Ruins.RuinModelUpdater
+= Timberborn.SlotSystem.PatrollingSlot
+  * NEW in v1.0.12 - added to blacklist
+= Timberborn.SlotSystem.PatrollingSlotFactory
+  * Addressed via PatrollingSlot blacklist
+= Timberborn.SlotSystem.SlotAnimationSynchronizer
+  * NEW in v1.0.12 - added to blacklist
+= Timberborn.SlotSystem.SlotManager
+  * Addressed via slot blacklists
+= Timberborn.SlotSystem.TransformSlot
+  * NEW in v1.0.12 - added to blacklist
+= Timberborn.SlotSystem.TransformSlotFactory
+  * Addressed via TransformSlot blacklist
+= Timberborn.SoundSystem.LoopingSoundPlayer
+= Timberborn.SoundSystem.Sounds
+= Timberborn.StockpileVisualization.GoodColumnVariantsService
+= Timberborn.StockpileVisualization.GoodPileVariantsService
+= Timberborn.StockpileVisualization.Pile
+  * NEW in v1.0.12 - addressed via existing StockpileVisualization blacklists
+= Timberborn.StockpileVisualization.StockpileGoodPileVisualizer
+= Timberborn.TerrainSystemRendering.TerrainBlockRandomizer
+= Timberborn.Wandering.VariedIdleAnimation
+  * NEW in v1.0.12 - added to blacklist
+= Timberborn.WaterBuildings.WaterInputPipeSegmentCreator
+= Timberborn.WorkshopsEffects.ObservatoryAnimator
+
+=== Map Editor only (not relevant for multiplayer gameplay) ===
+# Timberborn.BeaversUI.BeaverGeneratorTool
+  * Map editor tool
+# Timberborn.MapEditorNaturalResources.NaturalResourceSpawner
+  * Map editor only
+# Timberborn.MapEditorPlacementRandomizing.BlockObjectPlacementRandomizer
+  * Map editor only
+# Timberborn.MapEditorSceneLoading.MapEditorSceneLoader
+  * Map editor only
+
+=== Internal/Framework (not directly relevant) ===
+# Timberborn.Common.CommonConfigurator
+  * DI configuration
+# Timberborn.Common.FakeRandomNumberGeneratorFactory
+  * Testing utility
+# Timberborn.Common.RandomNumberGenerator
+  * The RNG implementation itself
+
+=== IParallelTickableSingleton implementations ===
+(These run in parallel during ticks - now forced sequential via NO_PARALLEL)
+= Timberborn.SoilContaminationSystem.SoilContaminationSimulator
+= Timberborn.SoilMoistureSystem.SoilMoistureSimulator
+= Timberborn.WaterSystem.WaterSimulator
+= Timberborn.WaterSystemRendering.WaterRenderer

--- a/BeaverBuddies/Events/AutomationEvents.cs
+++ b/BeaverBuddies/Events/AutomationEvents.cs
@@ -105,6 +105,8 @@ namespace BeaverBuddies.Events
                 (typeof(FireworkLauncher), nameof(FireworkLauncher.SetPitch)),
                 (typeof(FlowSensor), nameof(FlowSensor.SetMode)),
                 (typeof(FlowSensor), nameof(FlowSensor.SetThreshold)),
+                (typeof(Gate), nameof(Gate.EnableConflict)),
+                (typeof(Gate), nameof(Gate.DisableConflict)),
                 (typeof(Gate), nameof(Gate.SetOpeningMode)),
                 (typeof(Indicator), nameof(Indicator.SetColorReplicationEnabled)),
                 (typeof(Indicator), nameof(Indicator.SetJournalEntryEnabled)),
@@ -118,10 +120,12 @@ namespace BeaverBuddies.Events
                 // this an event, which will make the UI laggy, but I think that's
                 // unavoidable.
                 (typeof(Lever), nameof(Lever.SwitchState)),
+                (typeof(Lever), nameof(Lever.Toggle)),
                 (typeof(Memory), nameof(Memory.SetMode)),
                 (typeof(Memory), nameof(Memory.SetInputA)),
                 (typeof(Memory), nameof(Memory.SetInputB)),
                 (typeof(Memory), nameof(Memory.SetResetInput)),
+                (typeof(Memory), nameof(Memory.Reset)),
                 (typeof(PopulationCounter), nameof(PopulationCounter.SetComparisonMode)),
                 (typeof(PopulationCounter), nameof(PopulationCounter.SetCountBeavers)),
                 (typeof(PopulationCounter), nameof(PopulationCounter.SetCountBots)),
@@ -150,7 +154,9 @@ namespace BeaverBuddies.Events
                 (typeof(Timer), nameof(Timer.SetInput)),
                 (typeof(Timer), nameof(Timer.SetMode)),
                 (typeof(Timer), nameof(Timer.SetResetInput)),
+                (typeof(Timer), nameof(Timer.Reset)),
                 (typeof(WeatherStation), nameof(WeatherStation.SetEarlyActivationHours)),
+                (typeof(WeatherStation), nameof(WeatherStation.SetEarlyActivationEnabled)),
                 (typeof(WeatherStation), nameof(WeatherStation.SetMode)),
                 // Note: this intentionally omits the HTTPApi system because, well, that
                 // doesn't really make sense in multiplayer... at the very least it'd be

--- a/BeaverBuddies/Events/EntityUIEvents.cs
+++ b/BeaverBuddies/Events/EntityUIEvents.cs
@@ -1650,4 +1650,406 @@ namespace BeaverBuddies.Events
             return WaterSourceRegulatorStateChangedEvent.DoPrefix(__instance, false);
         }
     }
+
+    // ========== FillValve Events ==========
+    // FillValve controls water fill target height (reported as not syncing by players)
+
+    [Serializable]
+    class FillValveTargetHeightChangedEvent : ReplayEvent
+    {
+        public string entityID;
+        public float height;
+
+        public override void Replay(IReplayContext context)
+        {
+            var fillValve = GetComponent<FillValve>(context, entityID);
+            if (fillValve == null) return;
+            fillValve.SetTargetHeightAndSynchronize(height);
+        }
+
+        public override string ToActionString()
+        {
+            return $"Setting fill valve {entityID} target height to: {height}";
+        }
+    }
+
+    [HarmonyPatch(typeof(FillValve), nameof(FillValve.SetTargetHeightAndSynchronize))]
+    class FillValveSetTargetHeightPatcher
+    {
+        static bool Prefix(FillValve __instance, float value)
+        {
+            if (__instance.TargetHeight == value) return true;
+            return ReplayEvent.DoEntityPrefix(__instance, entityID =>
+            {
+                return new FillValveTargetHeightChangedEvent()
+                {
+                    entityID = entityID,
+                    height = value,
+                };
+            });
+        }
+    }
+
+    [Serializable]
+    class FillValveTargetHeightEnabledChangedEvent : ReplayEvent
+    {
+        public string entityID;
+        public bool enabled;
+
+        public override void Replay(IReplayContext context)
+        {
+            var fillValve = GetComponent<FillValve>(context, entityID);
+            if (fillValve == null) return;
+            fillValve.SetTargetHeightEnabledAndSynchronize(enabled);
+        }
+
+        public override string ToActionString()
+        {
+            return $"Setting fill valve {entityID} target height enabled to: {enabled}";
+        }
+    }
+
+    [HarmonyPatch(typeof(FillValve), nameof(FillValve.SetTargetHeightEnabledAndSynchronize))]
+    class FillValveSetTargetHeightEnabledPatcher
+    {
+        static bool Prefix(FillValve __instance, bool value)
+        {
+            if (__instance.TargetHeightEnabled == value) return true;
+            return ReplayEvent.DoEntityPrefix(__instance, entityID =>
+            {
+                return new FillValveTargetHeightEnabledChangedEvent()
+                {
+                    entityID = entityID,
+                    enabled = value,
+                };
+            });
+        }
+    }
+
+    [Serializable]
+    class FillValveAutomationTargetHeightChangedEvent : ReplayEvent
+    {
+        public string entityID;
+        public float height;
+
+        public override void Replay(IReplayContext context)
+        {
+            var fillValve = GetComponent<FillValve>(context, entityID);
+            if (fillValve == null) return;
+            fillValve.SetAutomationTargetHeightAndSynchronize(height);
+        }
+
+        public override string ToActionString()
+        {
+            return $"Setting fill valve {entityID} automation target height to: {height}";
+        }
+    }
+
+    [HarmonyPatch(typeof(FillValve), nameof(FillValve.SetAutomationTargetHeightAndSynchronize))]
+    class FillValveSetAutomationTargetHeightPatcher
+    {
+        static bool Prefix(FillValve __instance, float value)
+        {
+            if (__instance.AutomationTargetHeight == value) return true;
+            return ReplayEvent.DoEntityPrefix(__instance, entityID =>
+            {
+                return new FillValveAutomationTargetHeightChangedEvent()
+                {
+                    entityID = entityID,
+                    height = value,
+                };
+            });
+        }
+    }
+
+    [Serializable]
+    class FillValveAutomationTargetHeightEnabledChangedEvent : ReplayEvent
+    {
+        public string entityID;
+        public bool enabled;
+
+        public override void Replay(IReplayContext context)
+        {
+            var fillValve = GetComponent<FillValve>(context, entityID);
+            if (fillValve == null) return;
+            fillValve.SetAutomationTargetHeightEnabledAndSynchronize(enabled);
+        }
+
+        public override string ToActionString()
+        {
+            return $"Setting fill valve {entityID} automation target height enabled to: {enabled}";
+        }
+    }
+
+    [HarmonyPatch(typeof(FillValve), nameof(FillValve.SetAutomationTargetHeightEnabledAndSynchronize))]
+    class FillValveSetAutomationTargetHeightEnabledPatcher
+    {
+        static bool Prefix(FillValve __instance, bool value)
+        {
+            if (__instance.AutomationTargetHeightEnabled == value) return true;
+            return ReplayEvent.DoEntityPrefix(__instance, entityID =>
+            {
+                return new FillValveAutomationTargetHeightEnabledChangedEvent()
+                {
+                    entityID = entityID,
+                    enabled = value,
+                };
+            });
+        }
+    }
+
+    [Serializable]
+    class FillValveSynchronizationChangedEvent : ReplayEvent
+    {
+        public string entityID;
+        public bool isSynchronized;
+
+        public override void Replay(IReplayContext context)
+        {
+            var fillValve = GetComponent<FillValve>(context, entityID);
+            if (fillValve == null) return;
+            fillValve.ToggleSynchronization(isSynchronized);
+        }
+
+        public override string ToActionString()
+        {
+            return $"Setting fill valve {entityID} synchronization to: {isSynchronized}";
+        }
+    }
+
+    [HarmonyPatch(typeof(FillValve), nameof(FillValve.ToggleSynchronization))]
+    class FillValveToggleSynchronizationPatcher
+    {
+        static bool Prefix(FillValve __instance, bool value)
+        {
+            if (__instance.IsSynchronized == value) return true;
+            return ReplayEvent.DoEntityPrefix(__instance, entityID =>
+            {
+                return new FillValveSynchronizationChangedEvent()
+                {
+                    entityID = entityID,
+                    isSynchronized = value,
+                };
+            });
+        }
+    }
+
+    // ========== Valve Events ==========
+    // Valve controls water outflow limits (reported as not syncing by players)
+
+    [Serializable]
+    class ValveOutflowLimitChangedEvent : ReplayEvent
+    {
+        public string entityID;
+        public float outflowLimit;
+
+        public override void Replay(IReplayContext context)
+        {
+            var valve = GetComponent<Valve>(context, entityID);
+            if (valve == null) return;
+            valve.SetOutflowLimitAndSynchronize(outflowLimit);
+        }
+
+        public override string ToActionString()
+        {
+            return $"Setting valve {entityID} outflow limit to: {outflowLimit}";
+        }
+    }
+
+    [HarmonyPatch(typeof(Valve), nameof(Valve.SetOutflowLimitAndSynchronize))]
+    class ValveSetOutflowLimitPatcher
+    {
+        static bool Prefix(Valve __instance, float value)
+        {
+            if (__instance.OutflowLimit == value) return true;
+            return ReplayEvent.DoEntityPrefix(__instance, entityID =>
+            {
+                return new ValveOutflowLimitChangedEvent()
+                {
+                    entityID = entityID,
+                    outflowLimit = value,
+                };
+            });
+        }
+    }
+
+    [Serializable]
+    class ValveOutflowLimitEnabledChangedEvent : ReplayEvent
+    {
+        public string entityID;
+        public bool enabled;
+
+        public override void Replay(IReplayContext context)
+        {
+            var valve = GetComponent<Valve>(context, entityID);
+            if (valve == null) return;
+            valve.SetOutflowLimitEnabledAndSynchronize(enabled);
+        }
+
+        public override string ToActionString()
+        {
+            return $"Setting valve {entityID} outflow limit enabled to: {enabled}";
+        }
+    }
+
+    [HarmonyPatch(typeof(Valve), nameof(Valve.SetOutflowLimitEnabledAndSynchronize))]
+    class ValveSetOutflowLimitEnabledPatcher
+    {
+        static bool Prefix(Valve __instance, bool value)
+        {
+            if (__instance.OutflowLimitEnabled == value) return true;
+            return ReplayEvent.DoEntityPrefix(__instance, entityID =>
+            {
+                return new ValveOutflowLimitEnabledChangedEvent()
+                {
+                    entityID = entityID,
+                    enabled = value,
+                };
+            });
+        }
+    }
+
+    [Serializable]
+    class ValveAutomationOutflowLimitChangedEvent : ReplayEvent
+    {
+        public string entityID;
+        public float outflowLimit;
+
+        public override void Replay(IReplayContext context)
+        {
+            var valve = GetComponent<Valve>(context, entityID);
+            if (valve == null) return;
+            valve.SetAutomationOutflowLimitAndSynchronize(outflowLimit);
+        }
+
+        public override string ToActionString()
+        {
+            return $"Setting valve {entityID} automation outflow limit to: {outflowLimit}";
+        }
+    }
+
+    [HarmonyPatch(typeof(Valve), nameof(Valve.SetAutomationOutflowLimitAndSynchronize))]
+    class ValveSetAutomationOutflowLimitPatcher
+    {
+        static bool Prefix(Valve __instance, float value)
+        {
+            if (__instance.AutomationOutflowLimit == value) return true;
+            return ReplayEvent.DoEntityPrefix(__instance, entityID =>
+            {
+                return new ValveAutomationOutflowLimitChangedEvent()
+                {
+                    entityID = entityID,
+                    outflowLimit = value,
+                };
+            });
+        }
+    }
+
+    [Serializable]
+    class ValveAutomationOutflowLimitEnabledChangedEvent : ReplayEvent
+    {
+        public string entityID;
+        public bool enabled;
+
+        public override void Replay(IReplayContext context)
+        {
+            var valve = GetComponent<Valve>(context, entityID);
+            if (valve == null) return;
+            valve.SetAutomationOutflowLimitEnabledAndSynchronize(enabled);
+        }
+
+        public override string ToActionString()
+        {
+            return $"Setting valve {entityID} automation outflow limit enabled to: {enabled}";
+        }
+    }
+
+    [HarmonyPatch(typeof(Valve), nameof(Valve.SetAutomationOutflowLimitEnabledAndSynchronize))]
+    class ValveSetAutomationOutflowLimitEnabledPatcher
+    {
+        static bool Prefix(Valve __instance, bool value)
+        {
+            if (__instance.AutomationOutflowLimitEnabled == value) return true;
+            return ReplayEvent.DoEntityPrefix(__instance, entityID =>
+            {
+                return new ValveAutomationOutflowLimitEnabledChangedEvent()
+                {
+                    entityID = entityID,
+                    enabled = value,
+                };
+            });
+        }
+    }
+
+    [Serializable]
+    class ValveReactionSpeedChangedEvent : ReplayEvent
+    {
+        public string entityID;
+        public float reactionSpeed;
+
+        public override void Replay(IReplayContext context)
+        {
+            var valve = GetComponent<Valve>(context, entityID);
+            if (valve == null) return;
+            valve.SetReactionSpeedAndSynchronize(reactionSpeed);
+        }
+
+        public override string ToActionString()
+        {
+            return $"Setting valve {entityID} reaction speed to: {reactionSpeed}";
+        }
+    }
+
+    [HarmonyPatch(typeof(Valve), nameof(Valve.SetReactionSpeedAndSynchronize))]
+    class ValveSetReactionSpeedPatcher
+    {
+        static bool Prefix(Valve __instance, float value)
+        {
+            if (__instance.ReactionSpeed == value) return true;
+            return ReplayEvent.DoEntityPrefix(__instance, entityID =>
+            {
+                return new ValveReactionSpeedChangedEvent()
+                {
+                    entityID = entityID,
+                    reactionSpeed = value,
+                };
+            });
+        }
+    }
+
+    [Serializable]
+    class ValveSynchronizationChangedEvent : ReplayEvent
+    {
+        public string entityID;
+        public bool isSynchronized;
+
+        public override void Replay(IReplayContext context)
+        {
+            var valve = GetComponent<Valve>(context, entityID);
+            if (valve == null) return;
+            valve.ToggleSynchronization(isSynchronized);
+        }
+
+        public override string ToActionString()
+        {
+            return $"Setting valve {entityID} synchronization to: {isSynchronized}";
+        }
+    }
+
+    [HarmonyPatch(typeof(Valve), nameof(Valve.ToggleSynchronization))]
+    class ValveToggleSynchronizationPatcher
+    {
+        static bool Prefix(Valve __instance, bool value)
+        {
+            if (__instance.IsSynchronized == value) return true;
+            return ReplayEvent.DoEntityPrefix(__instance, entityID =>
+            {
+                return new ValveSynchronizationChangedEvent()
+                {
+                    entityID = entityID,
+                    isSynchronized = value,
+                };
+            });
+        }
+    }
 }

--- a/BeaverBuddies/Events/EntityUIEvents.cs
+++ b/BeaverBuddies/Events/EntityUIEvents.cs
@@ -2052,4 +2052,82 @@ namespace BeaverBuddies.Events
             });
         }
     }
+
+    // ========== Floodgate Automation Events ==========
+    // Floodgate automation height was not synced (reported by players)
+
+    [Serializable]
+    class FloodgateAutomationHeightChangedEvent : ReplayEvent
+    {
+        public string entityID;
+        public float height;
+
+        public override void Replay(IReplayContext context)
+        {
+            Floodgate floodgate = GetComponent<Floodgate>(context, entityID);
+            if (!floodgate) return;
+            floodgate.SetAutomationHeightAndSynchronize(height);
+        }
+
+        public override string ToActionString()
+        {
+            return $"Setting floodgate {entityID} automation height to: {height}";
+        }
+    }
+
+    [HarmonyPatch(typeof(Floodgate), nameof(Floodgate.SetAutomationHeightAndSynchronize))]
+    class FloodgateSetAutomationHeightPatcher
+    {
+        static bool Prefix(Floodgate __instance, float newAutomationHeight)
+        {
+            if (__instance.AutomationHeight == newAutomationHeight) return true;
+            return ReplayEvent.DoEntityPrefix(__instance, entityID =>
+            {
+                return new FloodgateAutomationHeightChangedEvent()
+                {
+                    entityID = entityID,
+                    height = newAutomationHeight,
+                };
+            });
+        }
+    }
+
+    // ========== SluiceState Additional Events ==========
+    // SluiceState toggle sync and auto-close toggles need patching too
+
+    [Serializable]
+    class SluiceStateSynchronizationChangedEvent : ReplayEvent
+    {
+        public string entityID;
+        public bool isSynchronized;
+
+        public override void Replay(IReplayContext context)
+        {
+            var sluice = GetComponent<Sluice>(context, entityID);
+            if (!sluice) return;
+            sluice._sluiceState.ToggleSynchronization(isSynchronized);
+        }
+
+        public override string ToActionString()
+        {
+            return $"Setting sluice {entityID} synchronization to: {isSynchronized}";
+        }
+    }
+
+    [HarmonyPatch(typeof(SluiceState), nameof(SluiceState.ToggleSynchronization))]
+    class SluiceStateToggleSynchronizationPatcher
+    {
+        static bool Prefix(SluiceState __instance, bool newValue)
+        {
+            if (__instance.IsSynchronized == newValue) return true;
+            return ReplayEvent.DoEntityPrefix(__instance, entityID =>
+            {
+                return new SluiceStateSynchronizationChangedEvent()
+                {
+                    entityID = entityID,
+                    isSynchronized = newValue,
+                };
+            });
+        }
+    }
 }

--- a/BeaverBuddies/Events/ToolEvents.cs
+++ b/BeaverBuddies/Events/ToolEvents.cs
@@ -163,9 +163,12 @@ namespace BeaverBuddies.Events
         {
             bool result = ReplayEvent.DoPrefix(() =>
             {
-                // TODO: If this does work, it may affect other deletions too :(
+                // Filter out null/destroyed components (e.g. paths on platforms
+                // that get destroyed when the platform is queued for deletion)
                 List<string> entityIDs = __instance._temporaryBlockObjects
+                        .Where(obj => obj != null && obj.GetComponent<EntityComponent>() != null)
                         .Select(ReplayEvent.GetEntityID)
+                        .Where(id => id != null)
                         .ToList();
 
                 return new BuildingsDeconstructedEvent()

--- a/BeaverBuddies/ReplayService.cs
+++ b/BeaverBuddies/ReplayService.cs
@@ -329,9 +329,11 @@ namespace BeaverBuddies
                     int randomS0Before = (int)replayEvent.randomS0Before;
                     if (s0 != randomS0Before)
                     {
-                        Plugin.LogWarning($"Random state mismatch: {s0:X8} != {randomS0Before:X8}");
-                        HandleDesync();
-                        break;
+                        Plugin.LogWarning($"Random state mismatch: {s0:X8} != {randomS0Before:X8} - resyncing");
+                        var state = UnityEngine.Random.state;
+                        state.s0 = randomS0Before;
+                        UnityEngine.Random.state = state;
+                        // Continue replaying - don't disconnect
                     }
                 }
                 try

--- a/BeaverBuddies/manifest.json
+++ b/BeaverBuddies/manifest.json
@@ -1,6 +1,6 @@
 {
-  "Name": "BeaverBuddies - Multiplayer Co-Op",
-  "Version": "1.6.6",
+  "Name": "BeaverBuddies - Multiplayer Co-Op (Desync Fix)",
+  "Version": "1.7.0",
   "Id": "beaverbuddies",
   "MinimumGameVersion": "0.7.2.0",
   "Description": "BeaverBuddies is a Timberborn mod that adds multiplayer co-op!",


### PR DESCRIPTION
## Summary
- Add 7 new visual RNG classes to blacklist for game v1.0.12 (CharacterTextureSetter, DeconstructionParticleFactory, BeaverInjuryTextureSetter, VariedIdleAnimation, PatrollingSlot, TransformSlot, SlotAnimationSynchronizer)
- Patch WateredNaturalResource.GenerateRandomDaysToDry, LivingWaterNaturalResource.GenerateRandomDaysToDie, and ContaminatedNaturalResource.GetDaysToDie for determinism (fixes #158)
- Add FillValve and Valve sync events — 13 new ReplayEvent subclasses (fixes #167)
- Add Floodgate automation height and SluiceState synchronization events
- Add 6 missing automation methods to patch list (Gate, Lever, Memory, Timer, WeatherStation)
- Filter null components in building demolition to prevent crash when demolishing platforms with paths (fixes #110)
- **Replace desync disconnect with lightweight RNG resync** — instead of disconnecting on random state mismatch, the client silently forces its RNG to match the host and continues playing. This handles minor desyncs (beaver position drift) without any interruption.

## Related issues
- Fixes #158 (WateredNaturalResource desync)
- Fixes #167 (FillValve/Valve not synced)
- Fixes #110 (crash on platform demolition)
- Related to #146 (new RNG classes in v1.0.12)

## Test plan
- [x] Tested 5h+ multiplayer session without desync or crash, on a fairly advanced part (10h+)
- [x] Verified FillValve, Valve, Floodgate automation sync
- [x] Verified platform+path demolition no longer crashes
- [x] Verified RNG resync works silently (warning in logs, no disconnect)
- [x] Build passes on Release Steam configuration