### PR TITLE
Add developer and user documentation as GitHub Pages site

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,61 @@
+# BeaverBuddies
+
+**Multiplayer Co-Op Mod for Timberborn**
+
+BeaverBuddies transforms Timberborn from a single-player city builder into a cooperative multiplayer experience. Multiple players can build and manage a beaver settlement together in real-time.
+
+> This documentation is for **developers** working on the BeaverBuddies mod. If you're a player looking to install and use the mod, please visit the [player wiki](https://github.com/thomaswp/BeaverBuddies/wiki).
+
+## Quick Links
+
+- [Getting Started](getting-started) - Set up your development environment
+- [Architecture Overview](architecture) - Understand how the mod is structured
+- [Contributing](contributing) - Learn how to contribute to the project
+- [Event System](event-system) - How player actions are synchronized
+- [Networking & IO](networking) - The network protocol and transport layer
+
+## Tech Stack
+
+| Component | Technology |
+|-----------|-----------|
+| Language | C# (.NET Standard 2.1) |
+| Game Modding | BepInEx 5.4.22 |
+| Runtime Patching | HarmonyX |
+| Dependency Injection | Bindito |
+| Networking | Custom TCP + Steam P2P (Steamworks.NET) |
+| Serialization | Newtonsoft.Json |
+| Settings | ModSettings framework |
+| Build System | MSBuild / Visual Studio 2022 |
+
+## How It Works
+
+BeaverBuddies uses an **event sourcing** architecture to synchronize game state across players:
+
+1. All player actions (building, demolition, speed changes, etc.) are captured as **events** via Harmony patches
+2. Events are serialized to JSON and transmitted over the network
+3. All clients **replay** events deterministically so their game states stay in sync
+4. A **tick synchronization** system ensures all clients advance the simulation in lockstep
+5. **Desync detection** catches divergences and can auto-report them for debugging
+
+## Project Structure
+
+```
+BeaverBuddies/              # Main mod (BepInEx plugin)
+  Connect/                   # Connection management & UI
+  DesyncDetecter/            # Desync detection & tracing
+  Editor/                    # Map editor extensions
+  Events/                    # Event definitions & Harmony patches
+  Fixes/                     # Determinism fixes for game systems
+  IO/                        # Event IO abstraction (network & file)
+  MultiStart/                # Multiple player starting locations
+  Reporting/                 # Error reporting
+  Steam/                     # Steam P2P networking & overlay
+  Util/                      # Utilities & logging
+TimberNet/                   # Standalone networking library
+ClientServerSimulator/       # Testing tool (Windows Forms)
+Inspector/                   # Utility tools
+```
+
+## Current Version
+
+**v1.6.6** - Minimum Timberborn version: **0.7.2.0**

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,11 @@
 
 BeaverBuddies transforms Timberborn from a single-player city builder into a cooperative multiplayer experience. Multiple players can build and manage a beaver settlement together in real-time.
 
-> This documentation is for **developers** working on the BeaverBuddies mod. If you're a player looking to install and use the mod, please visit the [player wiki](https://github.com/thomaswp/BeaverBuddies/wiki).
+[![BeaverBuddies Demo](https://github.com/thomaswp/BeaverBuddies/assets/1750176/41bb5d71-ff64-493c-a362-3c2483910b7d)](https://www.youtube.com/watch?v=m56GVA7XbI8)
+
+> **Players**: Check the [User Guide](user-guide) for installation and setup instructions.
+>
+> **Developers**: This documentation covers the full codebase architecture and internals.
 
 ## Quick Links
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,4 +1,8 @@
 - [Home](/)
+- **Player Guide**
+- [User Guide](user-guide)
+- [Port Forwarding](port-forwarding)
+- **Developer Guide**
 - [Getting Started](getting-started)
 - [Contributing](contributing)
 - **Architecture**

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,0 +1,16 @@
+- [Home](/)
+- [Getting Started](getting-started)
+- [Contributing](contributing)
+- **Architecture**
+- [Overview](architecture)
+- [Event System](event-system)
+- [Networking & IO](networking)
+- **Synchronization**
+- [Tick Synchronization](tick-synchronization)
+- [Determinism & Desync Detection](determinism)
+- **Game Systems**
+- [Connection Flow](connection-flow)
+- [Multiplayer Maps](multiplayer-maps)
+- **Reference**
+- [Configuration](configuration)
+- [Testing & Debugging](testing)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,258 @@
+# Architecture Overview
+
+This page describes the high-level architecture of BeaverBuddies, a multiplayer co-op mod for Timberborn.
+
+## Architecture Diagram
+
+```
++----------------------------------------------------------+
+|                      Plugin (IModStarter)                 |
+|          Harmony.PatchAll() + ApplyAutomationPatches()    |
++----+---------------------------+-------------------------+
+     |                           |
+     v                           v
++--------------------+   +---------------------------+
+| ReplayConfigurator |   | ConnectionMenuConfigurator|
+| [Context("Game")]  |   | [Context("MainMenu")]     |
++----+---------------+   +---------------------------+
+     |                        |
+     | (only if EventIO       | Registers:
+     |  is set)               |  ClientConnectionService
+     v                        |  ClientConnectionUI
++--------------------+        |  FirstTimerService
+| Co-op Services     |        |  ConfigIOService
+|  ReplayService     |        |  MultiplayerMapMetadataService
+|  TickingService    |        |  SteamOverlayConnectionService
+|  DeterminismService|        |  Settings
+|  TickProgressSvc   |        |
+|  TickReplacerSvc   |        |
+|  RehostingService  |        |
+|  ReportingService  |        |
+|  DesyncDetecterSvc |        |
++----+---------------+        |
+     |                        |
+     v                        v
++--------------------+   SingletonManager.Reset()
+| EventIO (interface)|   (called by both configurators)
++----+----------+----+
+     |          |
+     v          v
++---------+  +-----------+
+|ServerIO |  | ClientIO  |
++---------+  +-----------+
+     |          |
+     v          v
++-------------------------+
+| TimberNet               |
+| (TimberServer /         |
+|  TimberClient)          |
+| TCP + Steam transports  |
++-------------------------+
+```
+
+## Project Structure
+
+```
+BeaverBuddies/
+  Connect/          Client/server connection services, UI for joining/hosting
+  DesyncDetecter/   Desync detection and tracing (hash-based state comparison)
+  Editor/           In-game editor tools (debug/development utilities)
+  Events/           All ReplayEvent subclasses (ToolEvents, TimeEvents, etc.)
+  Fixes/            Harmony patches that fix Timberborn determinism issues
+  IO/               EventIO interface and implementations (ServerEventIO,
+                    ClientEventIO, FileWriteIO, FileReadIO, NetIOBase)
+  MultiStart/       Multi-instance launch support for testing
+  Reporting/        Desync bug reporting service (uploads logs/saves)
+  Steam/            Steam networking integration (overlay invites, P2P sockets)
+  Util/             Shared utilities, logging, reflection helpers
+```
+
+Key root-level files in the project:
+
+| File | Purpose |
+|------|---------|
+| `Plugin.cs` | Mod entry point, Harmony patching, configurators |
+| `SingletonManager.cs` | Custom singleton registry with reset support |
+| `ReplayService.cs` | Core orchestrator for event recording and replay |
+| `DeterminismService.cs` | Validates game state stays in sync across clients |
+| `TickingService.cs` | Controls tick progression and speed synchronization |
+| `TickProgressService.cs` | Tracks tick progress for UI feedback |
+| `TickReplacerService.cs` | Replaces Timberborn's tick system for co-op control |
+| `Settings.cs` | Mod configuration (port, debug mode, etc.) |
+
+## Plugin Entry Point
+
+The mod starts in `Plugin.cs`, which implements `IModStarter`:
+
+```csharp
+[HarmonyPatch]
+public class Plugin : IModStarter
+{
+    public void StartMod(IModEnvironment modEnvironment)
+    {
+        logger = new UnityLogger();
+        Log($"{Name} v{Version} is loaded!");
+
+        Harmony harmony = new Harmony(ID);
+        harmony.PatchAll();                              // Apply all [HarmonyPatch] attributes
+        AutomationEvent.ApplyAutomationPatches(harmony); // Apply reflection-based patches
+    }
+}
+```
+
+`Harmony.PatchAll()` scans the assembly for all classes decorated with `[HarmonyPatch]` and applies their prefix/postfix methods. `AutomationEvent.ApplyAutomationPatches()` handles a separate set of patches that are generated dynamically at runtime via reflection (see [Event System - AutomationEvents](event-system.md#automationeventscs---automation-component-interactions)).
+
+## Dependency Injection
+
+BeaverBuddies uses Timberborn's **Bindito** dependency injection framework. Two configurators register services into different scene contexts:
+
+### ReplayConfigurator (Game Context)
+
+Decorated with `[Context("Game")]`, this configurator runs when a game map loads. It performs two phases of registration:
+
+1. **Always registered** (even in single-player): `ClientConnectionService`, `ClientConnectionUI`, `SteamOverlayConnectionService`, `RegisteredLocalizationService`, `Settings`, and multi-start services.
+
+2. **Co-op only** (guarded by `if (EventIO.IsNull) return`): `ReplayService`, `TickProgressService`, `TickingService`, `DeterminismService`, `TickReplacerService`, `RehostingService`, `ReportingService`, `LateTickableBuffer`, and `DesyncDetecterService`.
+
+The guard on `EventIO.IsNull` is what distinguishes a regular single-player game from a co-op session. `EventIO` is set before the game scene loads -- by the connection flow that establishes server/client roles -- so if it is null, co-op services are skipped entirely.
+
+### ConnectionMenuConfigurator (MainMenu Context)
+
+Decorated with `[Context("MainMenu")]`, this configurator runs when the main menu loads. It registers UI and connection services needed before a game starts: `ClientConnectionService`, `ClientConnectionUI`, `FirstTimerService`, `ConfigIOService`, `MultiplayerMapMetadataService`, `SteamOverlayConnectionService`, and `Settings`.
+
+### Reset on Transition
+
+Both configurators call `SingletonManager.Reset()` as their first action. `ConnectionMenuConfigurator` additionally calls `EventIO.Reset()` to tear down any active network connection when returning to the main menu.
+
+## SingletonManager
+
+`SingletonManager` is a custom singleton registry that exists alongside (and independent of) Timberborn's own DI container. It provides a lightweight way for Harmony patches and static methods to access services without constructor injection.
+
+```csharp
+public static class SingletonManager
+{
+    private static Dictionary<Type, object> map = new Dictionary<Type, object>();
+
+    public static void Reset();                          // Calls IResettableSingleton.Reset() on each, then clears
+    public static T RegisterSingleton<T>(T singleton);   // Add to registry
+    public static T GetSingleton<T>();                   // Lookup by type, returns default if missing
+}
+```
+
+Services opt in by extending `RegisteredSingleton`, which auto-registers in its constructor:
+
+```csharp
+public class RegisteredSingleton
+{
+    public RegisteredSingleton()
+    {
+        SingletonManager.RegisterSingleton(this);
+    }
+}
+```
+
+The `IResettableSingleton` interface allows singletons with static state to clean up when the scene transitions (e.g., returning to the main menu or loading a new map):
+
+```csharp
+public interface IResettableSingleton
+{
+    void Reset();
+}
+```
+
+This is important because Harmony patches reference static fields that persist across scene loads. Without explicit reset, stale references from a previous game session could cause errors.
+
+## Server vs Client Architecture
+
+BeaverBuddies uses an **event sourcing** pattern to keep multiple game instances in sync. Both the server and all clients run the full Timberborn simulation independently. Rather than transmitting game state, only player actions (as `ReplayEvent` objects) are exchanged. Because the simulation is deterministic, applying the same events in the same order produces identical game states.
+
+### UserEventBehavior
+
+The `UserEventBehavior` enum controls how user-initiated actions are handled depending on the role:
+
+| Value | Used By | Behavior |
+|-------|---------|----------|
+| `Play` | `FileWriteIO` | Execute the action locally immediately (single-player recording) |
+| `Send` | `ClientEventIO` | Do not execute locally; send the event to the server for approval |
+| `QueuePlay` | `ServerEventIO` | Queue the event to play on the next tick (ensures ordering consistency) |
+
+### Data Flow
+
+**Server (host):**
+1. Player performs an action (e.g., places a building)
+2. Harmony prefix intercepts the call, creates a `ReplayEvent`
+3. Event is queued (not executed immediately) via `QueuePlay`
+4. At the start of the next tick, queued events are played and broadcast to clients
+5. Server sends a `HeartbeatEvent` each tick so clients know to advance
+
+**Client (joiner):**
+1. Player performs an action
+2. Harmony prefix intercepts the call, creates a `ReplayEvent`
+3. Event is sent to the server (`Send` behavior); the local action is cancelled (prefix returns `false`)
+4. Server receives the event, queues it, and broadcasts it back to all clients on the next tick
+5. Client receives the event and replays it locally
+
+### EventIO Interface
+
+The `EventIO` interface abstracts the transport layer:
+
+```csharp
+public interface EventIO
+{
+    void Update();
+    List<ReplayEvent> ReadEvents(int ticksSinceLoad);
+    void WriteEvents(params ReplayEvent[] events);
+    void Close();
+    bool RecordReplayedEvents { get; }
+    UserEventBehavior UserEventBehavior { get; }
+    bool IsOutOfEvents { get; }
+    bool ShouldSendHeartbeat { get; }
+    bool HasEventsForTick(int tick);
+}
+```
+
+Implementations:
+
+- **`ServerEventIO`** -- Wraps `TimberServer`. Records replayed events, sends heartbeats, queues user events.
+- **`ClientEventIO`** -- Wraps `TimberClient`. Does not re-record received events, sends user events to server.
+- **`FileWriteIO`** -- Writes events to a JSON file for replay recording.
+- **`FileReadIO`** -- Reads events from a JSON file for replay playback.
+
+The network implementations (`ServerEventIO`, `ClientEventIO`) extend `NetIOBase<T>`, which handles JSON serialization/deserialization of events via `JObject` and the `JsonSettings` serializer.
+
+## Key Design Patterns
+
+### Event Sourcing
+
+All player actions are captured as serializable `ReplayEvent` objects. The game state is a function of the initial save file plus the ordered sequence of events applied to it. This means:
+- No game state is transmitted over the network (only events)
+- Events can be saved to a file and replayed later
+- Desyncs can be detected by comparing state hashes at each tick
+
+### Deterministic Replay
+
+Both server and client run identical simulations. The `DeterminismService` tracks the random number generator state (`randomS0Before` on each event) and other game state hashes to verify that all participants remain in sync. The `Fixes/` directory contains Harmony patches that correct non-deterministic behavior in Timberborn (e.g., hash set iteration order, parallel execution).
+
+### Harmony Method Interception
+
+Nearly every synced player action is captured via Harmony **prefix patches**. The standard pattern is:
+
+```csharp
+[HarmonyPatch(typeof(TargetClass), nameof(TargetClass.TargetMethod))]
+class TargetMethodPatcher
+{
+    static bool Prefix(/* parameters */)
+    {
+        return ReplayEvent.DoPrefix(() =>
+        {
+            return new SomeEvent() { /* populate fields */ };
+        });
+    }
+}
+```
+
+The prefix returns `false` to cancel the original method when the event should not execute locally (client behavior), or `true` to allow it (server/replay behavior). This is controlled by `EventIO.ShouldPlayPatchedEvents`.
+
+### Transport Abstraction
+
+The `EventIO` interface decouples the event system from any specific transport. The same `ReplayService` works with TCP networking, Steam P2P, or file-based replay without modification. The `NetIOBase<T>` class provides shared serialization logic for the network transports, while `FileWriteIO` and `FileReadIO` handle offline recording and playback.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,222 @@
+# Configuration
+
+This page covers BeaverBuddies settings, build configurations, environment setup, localization, and assembly publicizing.
+
+## Settings Class
+
+**File:** `BeaverBuddies/Settings.cs`
+
+`Settings` extends `ModSettingsOwner` (from the ModSettings mod) and exposes all configurable options through the Timberborn mod settings UI.
+
+### Connection Settings
+
+| Setting | Type | Default | Description |
+|---|---|---|---|
+| `ClientConnectionAddress` | `string` | `"127.0.0.1"` | Last-used server address for joining games |
+| `DefaultPort` | `int` | `25565` | TCP port for direct connections |
+
+### Steam Settings
+
+| Setting | Type | Default | Description |
+|---|---|---|---|
+| `EnableSteamConnection` | `bool` | `true` | Whether to enable Steam P2P connectivity |
+| `FriendsCanJoinSteamGame` | `bool` | `true` | Whether Steam friends can join without an invite |
+
+### Developer Settings
+
+| Setting | Type | Default | Description |
+|---|---|---|---|
+| `AlwaysTrace` | `bool` | `false` | Enable detailed desync tracing (see [Determinism](determinism.md)) |
+| `SilenceLogging` | `bool` | `false` | Suppress verbose log output |
+
+### User Settings
+
+| Setting | Type | Default | Description |
+|---|---|---|---|
+| `ShowFirstTimerMessage` | `bool` | `true` | Show welcome dialog on first load |
+| `ReportingConsent` | `bool` | `false` | Allow automated desync report submission |
+
+### Static Accessors
+
+For convenience, `Settings` provides static properties that can be accessed without a reference to the singleton instance:
+
+```csharp
+public static bool Debug => TemporarilyDebug || (instance?.AlwaysTrace.Value ?? false);
+public static bool VerboseLogging => !(instance?.SilenceLogging.Value == true);
+public static int Port => instance?.DefaultPort.Value ?? 25565;
+public static bool EnableSteam => instance?.EnableSteamConnection.Value ?? true;
+public static bool LobbyJoinable => instance?.FriendsCanJoinSteamGame.Value ?? true;
+```
+
+### TemporarilyDebug
+
+`Settings.TemporarilyDebug` is a non-persisted static flag. When set to `true`, it enables `Settings.Debug` for the current session without modifying the saved `AlwaysTrace` setting. This is useful for one-time debugging -- see [Testing and Debugging](testing.md).
+
+## ConfigIOService (Legacy Migration)
+
+**File:** `BeaverBuddies/ConfigIOService.cs`
+
+`ConfigIOService` is an `IPostLoadableSingleton` that handles migration from the legacy `ReplayConfig.json` file to the modern ModSettings system.
+
+On `PostLoad()`, it checks for a `ReplayConfig.json` file in the mod directory. If found:
+
+1. Reads the JSON into a `ReplayConfig` object.
+2. Transfers each field to the corresponding `ModSetting`:
+   - `ClientConnectionAddress` -> `Settings.ClientConnectionAddress`
+   - `Port` -> `Settings.DefaultPort`
+   - `Verbose` -> `Settings.SilenceLogging` (inverted)
+   - `FirstTimer` -> `Settings.ShowFirstTimerMessage`
+   - `ReportingConsent` -> `Settings.ReportingConsent`
+   - `AlwaysDebug` -> `Settings.AlwaysTrace`
+3. Deletes the old config file.
+
+This ensures a smooth upgrade path for existing users.
+
+## Build Configurations
+
+**File:** `BeaverBuddies/BeaverBuddies.csproj`
+
+The project defines four build configurations:
+
+| Configuration | Description |
+|---|---|
+| `Debug` | Standard debug build without Steam features |
+| `Release` | Optimized build without Steam features |
+| `Debug Steam` | Debug build with Steam integration |
+| `Release Steam` | Release build with Steam integration |
+
+The Steam configurations define the `IS_STEAM` preprocessor symbol:
+
+```xml
+<PropertyGroup Condition="'$(Configuration)' == 'Debug Steam' OR '$(Configuration)' == 'Release Steam'">
+  <DefineConstants>$(DefineConstants);IS_STEAM</DefineConstants>
+</PropertyGroup>
+```
+
+Code that depends on Steam is wrapped in `#if IS_STEAM` / `#endif` blocks. This includes:
+
+- `SteamOverlayConnectionService` (lobby management and join handling)
+- `SteamOverlayInputBlockerPatch` (overlay input blocking)
+- Steam listener creation in `ServerEventIO`
+
+The non-Steam builds compile stub implementations (e.g., empty `UpdateSingleton()`) to satisfy interface requirements.
+
+## env.props Reference
+
+The build system uses an `env.props` MSBuild file to locate system-specific paths. If `env.props` does not exist, the build automatically copies from the appropriate template (`env.props.windows-template` or `env.props.unix-template`).
+
+### Required Properties
+
+| Property | Description |
+|---|---|
+| `TimberbornDataPath` | Path to Timberborn's data directory (containing `Managed/`) |
+| `BepInExPath` | Path to BepInEx installation (containing `core/`) |
+| `ModSettingsPath` | Path to the ModSettings mod's `Scripts/` directory |
+| `DocumentsPath` | User documents directory (where `Timberborn/Mods/` lives) |
+
+All paths must end with a trailing slash.
+
+### Windows Example (env.props.windows-template)
+
+```xml
+<TimberbornDataPath>C:\Program Files (x86)\Steam\steamapps\common\Timberborn\Timberborn_Data\</TimberbornDataPath>
+<BepInExPath>C:\Dev\BepInEx\</BepInExPath>
+<ModSettingsPath>C:\Program Files (x86)\Steam\steamapps\workshop\content\1062090\3283831040\version-0.7\Scripts\</ModSettingsPath>
+<DocumentsPath>$(registry:HKEY_CURRENT_USER\...\User Shell Folders@Personal)\</DocumentsPath>
+```
+
+Note: The Windows template reads `DocumentsPath` from the registry to handle non-standard document folder locations.
+
+### macOS Example (env.props.unix-template)
+
+```xml
+<TimberbornDataPath>$(HOME)/Library/Application Support/Steam/steamapps/common/Timberborn/Timberborn.app/Contents/Resources/Data/</TimberbornDataPath>
+<BepInExPath>$(HOME)/dev/BepInEx/BepInEx/</BepInExPath>
+<ModSettingsPath>$(HOME)/Documents/Timberborn/Mods/modsettings-ey0f/version-1.0/Scripts/</ModSettingsPath>
+<DocumentsPath>$(HOME)/Documents/</DocumentsPath>
+```
+
+### Build Validation
+
+The `CheckEnv` target runs before each build and verifies all four directories exist:
+
+```xml
+<Error Text="TimberbornDataPath property directory not found" Condition="!Exists('$(TimberbornDataPath)')" />
+<Error Text="BepInExPath property directory not found" Condition="!Exists('$(BepInExPath)')" />
+<Error Text="ModSettingsPath property directory not found" Condition="!Exists('$(ModSettingsPath)')" />
+<Error Text="DocumentsPath property directory not found" Condition="!Exists('$(DocumentsPath)')" />
+```
+
+### Output Deployment
+
+The `PostBuild` target copies the compiled mod to `$(DocumentsPath)Timberborn\Mods\BeaverBuddies\`, making it immediately available in Timberborn.
+
+## Assembly Publicizing
+
+BeaverBuddies needs access to many private and internal members of Timberborn's assemblies. Rather than using reflection everywhere, the project uses `BepInEx.AssemblyPublicizer.MSBuild`:
+
+```xml
+<PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.3">
+  <PrivateAssets>all</PrivateAssets>
+  <PublicizeCompilerGenerated>false</PublicizeCompilerGenerated>
+</PackageReference>
+```
+
+Assembly references that need publicizing are marked with `Publicize="true"`:
+
+```xml
+<Reference Include="$(TimberbornManagedPath)UnityEngine.*.dll" Publicize="true" Private="false" />
+<Reference Include="$(TimberbornManagedPath)Timberborn.*.dll" Publicize="true" Private="false" />
+```
+
+This makes all private fields, methods, and properties accessible at compile time. Code that relies on this access is annotated with `[ManualMethodOverwrite]` to flag methods that duplicate Timberborn internals and may need updating when the game updates.
+
+## Localization
+
+### Localization Files
+
+BeaverBuddies ships localization CSV files in the `BeaverBuddies/Localizations/` directory. Currently supported languages:
+
+| File | Language |
+|---|---|
+| `enUS_BeaverBuddie.csv` | English (US) |
+| `deDE_BeaverBuddie.csv` | German |
+| `esES_BeaverBuddie.csv` | Spanish |
+| `frFR_BeaverBuddie.csv` | French |
+| `itIT_BeaverBuddie.csv` | Italian |
+| `jaJP_BeaverBuddie.csv` | Japanese |
+| `koKR_BeaverBuddie.csv` | Korean |
+| `plPL_BeaverBuddie.csv` | Polish |
+| `ptBR_BeaverBuddie.csv` | Portuguese (Brazil) |
+| `ruRU_BeaverBuddie.csv` | Russian |
+| `thTH_BeaverBuddie.csv` | Thai |
+| `trTR_BeaverBuddie.csv` | Turkish |
+| `ukUA_BeaverBuddie.csv` | Ukrainian |
+| `zhCN_BeaverBuddie.csv` | Chinese (Simplified) |
+| `zhTW_BeaverBuddie.csv` | Chinese (Traditional) |
+
+These files are copied to the output directory during build and deployed with the mod.
+
+### RegisteredLocalizationService
+
+**File:** `BeaverBuddies/Util/RegisteredLocalizationService.cs`
+
+A thin wrapper around Timberborn's `ILoc` interface, registered as a singleton:
+
+```csharp
+public class RegisteredLocalizationService : RegisteredSingleton
+{
+    public ILoc ILoc { get; private set; }
+
+    public static string T(string key)
+    {
+        return SingletonManager.GetSingleton<RegisteredLocalizationService>().ILoc.T(key);
+    }
+}
+```
+
+The static `T()` method provides convenient access to localized strings from anywhere in the codebase, including Harmony patches and static contexts where dependency injection is not available. Localization keys follow the pattern `BeaverBuddies.<Category>.<Key>`.
+
+### Updating Localizations
+
+The `Inspector` project includes an `UpdateLocalizations` utility (see [Testing and Debugging](testing.md)) that parses structured translation input and merges new entries into the CSV files.

--- a/docs/connection-flow.md
+++ b/docs/connection-flow.md
@@ -1,0 +1,175 @@
+# Connection and Session Management
+
+This page documents how BeaverBuddies establishes multiplayer sessions, from the UI entry points through network connection to game loading.
+
+## Hosting a Game
+
+### UI Entry Point
+
+The hosting flow begins in the load game screen. `LoadGameBoxGetPanelPatcher` (in `BeaverBuddies/Connect/ServerHostingUtils.cs`) patches `LoadGameBox.GetPanel` to add a **"Host Co-op Game"** button next to the standard Load button:
+
+```csharp
+ButtonInserter.DuplicateOrGetButton(__result, "LoadButton", "HostButton", (button) =>
+{
+    button.text = _loc.T("BeaverBuddies.Saving.HostCoopGame");
+    button.clicked += () => HostSelectedGame(__instance);
+});
+```
+
+When clicked, `HostSelectedGame` validates the save and calls `ServerHostingUtils.LoadIfSaveValidAndHost()`.
+
+### LoadAndHost Flow
+
+`ServerHostingUtils.LoadAndHost()` orchestrates the full hosting sequence:
+
+1. **Read map bytes** -- `GetMapBtyes()` reads the save file into a byte array via `GameSaveRepository.OpenSaveWithoutLogging()`.
+
+2. **Create ServerEventIO** -- A new `ServerEventIO` is created and set as the active `EventIO`. This starts the TCP server (and optionally a Steam listener) and begins accepting connections.
+
+3. **Show waiting dialog** -- A dialog box displays connected clients in real time. A coroutine (`UpdateDialogBox`) polls `io.NetBase.GetConnectedClients()` each frame and updates the dialog label. If Steam is available, an "Invite Friends" button appears that calls `SteamListener.ShowInviteFriendsPanel()`.
+
+4. **Start Game button** -- When the host clicks "Start Game":
+   - The coroutine is stopped.
+   - `DeterminismService.InitGameStartState(data)` seeds the RNG from the map hash.
+   - `GameSceneLoader.StartSaveGame(saveReference)` loads the save.
+
+5. **Stop accepting clients** -- After the first tick, the server stops accepting new connections (`StopAcceptingClients`).
+
+### Save Validation
+
+`LoadIfSaveValidAndHost` replicates the `ValidatingGameLoader.CheckNextValidator` pattern, iterating through all `IGameLoadValidator` instances before proceeding to `LoadAndHost`. This ensures modded or corrupted saves are caught before hosting.
+
+## Joining a Game
+
+### Direct IP Connection
+
+**File:** `BeaverBuddies/Connect/ClientConnectionService.cs`
+
+`ClientConnectionService.TryToConnect(string address)` handles direct IP connections:
+
+1. **Parse address and port** -- `TryParseHostAndPort()` uses a dummy URI scheme (`tcp://`) to parse the input. It supports IPv4, IPv6 (bracketed), and hostnames. Port defaults to `Settings.Port` (25565) if not specified.
+
+2. **Resolve hostname** -- If the address is not a valid IP, `ResolveHostnameIfNecessary()` calls `Dns.GetHostEntry()` and uses the first result.
+
+3. **Create TCP connection** -- A `TCPClientWrapper` is created with the resolved address and port.
+
+4. **Create ClientEventIO** -- `ClientEventIO.Create(socket, LoadMap, onError)` wraps the socket in a `TimberClient`, connects to the server, and waits for the map data.
+
+5. **Load the map** -- The `LoadMap` callback:
+   - Calls `SingletonManager.Reset()` to clean up existing state.
+   - Saves the received map bytes to disk under the "Online Games" directory with a hash-based name.
+   - Calls `DeterminismService.InitGameStartState(mapBytes)` to seed the RNG identically to the server.
+   - Calls `GameSceneLoader.StartSaveGame()` to load the save.
+
+### Steam Connection
+
+`ClientConnectionService.TryToConnect(CSteamID friendID)` creates a `SteamSocket` directly from a Steam friend's ID, then follows the same `ClientEventIO.Create` flow.
+
+### Error Handling
+
+Connection failures show a localized dialog with the specific error reason (invalid format, invalid address, connection failed) and a button linking to the troubleshooting URL.
+
+## Steam Integration
+
+### SteamOverlayConnectionService
+
+**File:** `BeaverBuddies/Steam/SteamOverlayConnectionService.cs`
+
+This service manages Steam overlay integration for joining games. It is conditionally compiled with `#if IS_STEAM`.
+
+On initialization (when `SteamManager.Initialized` becomes true):
+
+- Registers Steamworks callbacks:
+  - `GameLobbyJoinRequested_t` -- When a player accepts a Steam invite, joins the lobby.
+  - `LobbyEnter_t` -- After entering a lobby, if the current player is not the owner, connects to the lobby owner via `ClientConnectionService.TryToConnect(owner)`.
+  - `P2PSessionRequest_t` -- Accepts incoming P2P session requests.
+
+The service also handles the case where the Steam overlay is still open when the connection completes, deferring the success/failure dialog until the overlay closes (via `PanelHiddenEvent`).
+
+### SteamListener
+
+**File:** `BeaverBuddies/Steam/SteamListener.cs`
+
+`SteamListener` implements `ISocketListener` for the server side:
+
+- `Start()` creates a Steam lobby. The lobby type is determined by `Settings.LobbyJoinable`:
+  - `true` -> `ELobbyType.k_ELobbyTypeFriendsOnly` (friends can see and join)
+  - `false` -> `ELobbyType.k_ELobbyTypeInvisible` (invite-only)
+- `OnLobbyChatUpdate` detects when a user joins the lobby, creates a `SteamSocket` for them, registers it with the `SteamPacketListener`, and enqueues it for acceptance.
+- `AcceptClient()` blocks until a new client is available in the `joiningUsers` queue.
+- `ShowInviteFriendsPanel()` opens the Steam overlay invite dialog via `SteamFriends.ActivateGameOverlayInviteDialog`.
+- `Stop()` leaves the lobby and disposes all callbacks.
+
+### SteamSocket
+
+`SteamSocket` (in `BeaverBuddies/Steam/SteamSocket.cs`) implements `ISocketStream` over Steam P2P networking. It wraps `SteamNetworking` API calls for sending and receiving packets.
+
+### SteamOverlayInputBlockerPatch
+
+`SteamOverlayInputBlockerPatch` (in `BeaverBuddies/Steam/SteamOverlayInputBlockerPatch.cs`) prevents game input from being processed while the Steam overlay is open. This is only compiled in Steam builds (`IS_STEAM`).
+
+## Rehosting
+
+**File:** `BeaverBuddies/Connect/RehostingService.cs`
+
+`RehostingService` allows the server to restart a session after a desync or other issue without returning to the main menu.
+
+### RehostGame Flow
+
+1. `RehostGame()` calls `SaveRehostFile()` with a callback to reload.
+2. `SaveRehostFile()`:
+   - Creates a timestamped save reference (e.g., "2026-04-06 12-00-00 Rehost").
+   - Calls `GameSaver.SaveInstantlySkippingNameValidation()` to write the save.
+   - When `waitUntilAccessible` is true, the callback is deferred by one frame (via `TimeoutUtils.RunAfterFrames`) to ensure the save stream is released.
+3. The callback calls `ServerHostingUtils.LoadIfSaveValidAndHost()`, which starts the full hosting flow with the new save.
+
+This effectively creates a new session from the current game state, allowing disconnected clients to rejoin.
+
+## UI Components
+
+### ClientConnectionUI
+
+**File:** `BeaverBuddies/Connect/ClientConnectionUI.cs`
+
+Adds a **"Join Co-op Game"** button to both the main menu (`MainMenuGetPanelPatcher`) and the in-game options menu (`GameOptionsBoxGetPanelPatcher`). Uses `ButtonInserter.DuplicateOrGetButton` to clone an existing button's style.
+
+When clicked, shows an input dialog (via `InputBoxShower`) pre-filled with the last-used address from `Settings.ClientConnectionAddress`. The input supports up to 128 characters (overriding the default) to accommodate IPv6 addresses and hostnames.
+
+### ButtonInserter
+
+**File:** `BeaverBuddies/Connect/ButtonInserter.cs`
+
+Utility class that duplicates an existing UI button by name, giving it a new name and configuration callback. This ensures buttons match the game's visual style without custom UXML.
+
+### FirstTimerService
+
+**File:** `BeaverBuddies/Connect/FirstTimerService.cs`
+
+An `IPostLoadableSingleton` that shows a welcome dialog the first time a player loads the game with BeaverBuddies installed. The dialog provides a link to the guide (via `LinkHelper.GuideURL`). After the player clicks either the guide link or cancel, `Settings.ShowFirstTimerMessage` is set to `false` so the dialog does not appear again.
+
+## Connection Sequence Diagram
+
+```
+Server                                Client
+  |                                      |
+  |  LoadAndHost()                       |
+  |  - Read save bytes                   |
+  |  - Create ServerEventIO             |
+  |  - Start TCP/Steam listener          |
+  |  - Show waiting dialog               |
+  |                                      |
+  |  <---- TCP/Steam connect ----------  |  TryToConnect()
+  |  ---- Send map bytes ------------->  |
+  |                                      |  LoadMap()
+  |  Host clicks "Start Game"            |  - Reset singletons
+  |  - InitGameStartState(bytes)         |  - Save map to disk
+  |  - StartSaveGame()                   |  - InitGameStartState(bytes)
+  |                                      |  - StartSaveGame()
+  |                                      |
+  |  [Both load with identical           |
+  |   RNG seed and save data]            |
+  |                                      |
+  |  First tick completes                |
+  |  - StopAcceptingClients()            |
+  |                                      |
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,6 +2,12 @@
 
 This guide covers how to contribute to BeaverBuddies, including code conventions, common workflows, and how to add new synchronized actions.
 
+## Resources
+
+- [Video tutorial](https://www.youtube.com/watch?v=xD7x8R580N0) - Walkthrough of fixing a desync caused by an unimplemented UI event
+- [Issue tracker](https://github.com/thomaswp/BeaverBuddies/issues) - Find issues to work on
+- [Timberborn modding guide](https://timberborn.wiki.gg/wiki/Creating_Mods) - Helpful background, though BeaverBuddies doesn't use a typical modding workflow
+
 ## Development Workflow
 
 1. Fork the repository and clone your fork

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,131 @@
+# Contributing
+
+This guide covers how to contribute to BeaverBuddies, including code conventions, common workflows, and how to add new synchronized actions.
+
+## Development Workflow
+
+1. Fork the repository and clone your fork
+2. Follow the [Getting Started](getting-started) guide to set up your environment
+3. Create a feature branch from `dev`
+4. Implement your changes
+5. Test with two game instances (host + client) or the ClientServerSimulator
+6. Submit a pull request to `dev`
+
+## Code Conventions
+
+### Naming
+
+- **PascalCase** for public members, types, and methods
+- **camelCase** for private fields and local variables
+- **_underscore prefix** for injected dependencies (e.g., `_replayService`)
+- Harmony patch classes: `{TargetClass}{Method}Patcher` (e.g., `SpeedManagerChangeSpeedPatcher`)
+
+### Harmony Patches
+
+BeaverBuddies uses HarmonyX to intercept Timberborn game methods at runtime. Key conventions:
+
+- Prefix patches are the primary mechanism for capturing player actions
+- Use `[HarmonyPatch]` attributes on patch classes
+- Patch methods are typically `static bool Prefix(...)` returning whether the original method should execute
+
+### ManualMethodOverwrite
+
+When a Harmony patch must copy and modify Timberborn source code (rather than just wrapping it), mark it with the `[ManualMethodOverwrite]` attribute. This signals that the patch contains game code that may break when Timberborn updates.
+
+When updating for a new Timberborn version, search for all `[ManualMethodOverwrite]` usages and verify the copied code still matches the game's current implementation.
+
+## Adding a New Synced Action
+
+The most common contribution is adding synchronization for a game action that isn't yet replicated in multiplayer. Here's the pattern:
+
+### 1. Create a ReplayEvent Subclass
+
+```csharp
+public class MyNewEvent : ReplayEvent
+{
+    public string someData;
+
+    public override void Replay(IReplayContext context)
+    {
+        // Execute the action during replay
+        var service = context.GetSingleton<SomeService>();
+        service.DoSomething(someData);
+    }
+}
+```
+
+### 2. Write a Harmony Prefix Patch
+
+```csharp
+[HarmonyPatch(typeof(TargetClass), nameof(TargetClass.TargetMethod))]
+public static class TargetClassTargetMethodPatcher
+{
+    public static bool Prefix(TargetClass __instance, string parameter)
+    {
+        return ReplayEvent.DoPrefix(
+            () => new MyNewEvent
+            {
+                someData = parameter
+            }
+        );
+    }
+}
+```
+
+The `DoPrefix()` helper handles the full lifecycle:
+- If this is normal gameplay: creates the event, records it, and returns `true` (letting the original method run)
+- If this is during replay: returns `false` (the event's `Replay()` method handles execution instead)
+- If replay service isn't ready: returns `true` (lets the game run normally in single-player)
+
+### 3. For Entity-Based Actions
+
+If the action targets a specific game entity (building, beaver, etc.), use `DoEntityPrefix`:
+
+```csharp
+public static bool Prefix(BuildingComponent __instance, int value)
+{
+    return ReplayEvent.DoEntityPrefix(
+        __instance,
+        () => new MyEntityEvent
+        {
+            entityID = __instance.GetComponentFast<EntityComponent>().EntityId,
+            newValue = value
+        }
+    );
+}
+```
+
+### 4. Test Your Changes
+
+1. **Two-instance test:** Host a game on one Timberborn instance, join from another. Perform the action on both sides and verify it syncs correctly.
+2. **ClientServerSimulator:** For automated testing, create JSON event scripts and use the simulator (see [Testing & Debugging](testing)).
+3. **Desync check:** Play for several minutes after your action to verify no desyncs occur. Enable `AlwaysTrace` in settings for detailed tracing.
+
+## Diagnosing Desyncs
+
+When a desync occurs, it means the game state has diverged between server and client. Common causes:
+
+1. **Missing event capture** - A game action modifies state but isn't intercepted by a Harmony patch
+2. **Non-deterministic code** - Code that uses `Time.time`, `Random` outside the seeded RNG, or other frame-dependent values
+3. **Parallel tick ordering** - Systems that tick in parallel may execute in different orders
+4. **Floating point divergence** - Accumulated rounding differences between machines
+
+### Debugging Workflow
+
+1. Enable `AlwaysTrace` in mod settings
+2. Reproduce the desync
+3. Check the BepInEx console/log for trace output
+4. Compare server and client traces to find where they diverge
+5. The divergence point indicates which system or event caused the desync
+
+See [Determinism & Desync Detection](determinism) for detailed information on the detection system.
+
+## Updating for New Timberborn Versions
+
+When Timberborn releases an update:
+
+1. Update game DLL references in your `env.props` if paths changed
+2. Build and check for compile errors (API changes)
+3. Search for `[ManualMethodOverwrite]` - each marks a patch that copies Timberborn code. Verify the copied code still matches the game's current version
+4. Test all major features: hosting, joining, building, demolition, speed control, etc.
+5. Run a full multiplayer session to check for new desyncs

--- a/docs/determinism.md
+++ b/docs/determinism.md
@@ -1,0 +1,227 @@
+# Determinism and Desync Detection
+
+BeaverBuddies uses a **lockstep simulation** model: both the server and client execute the same game logic with the same inputs and must produce identical results. This page explains how determinism is enforced and how desyncs are detected when it fails.
+
+## Why Determinism Matters
+
+Timberborn is a single-player game. Many of its internal systems use patterns that are inherently non-deterministic:
+
+- **Random number generation** is used throughout gameplay logic (resource reproduction, beaver behavior, GUID creation) but also in UI/audio code. Without control, these share the same RNG state, causing divergence.
+- **Rendering and audio** systems call into game code during `Update()` cycles, potentially mutating shared state.
+- **Parallel tick execution** processes water simulation and other systems on background threads, which can execute in non-deterministic order.
+- **Time.time** varies between machines based on frame rate and real-world timing.
+
+If any of these cause the server and client to reach a different game state, the simulation diverges -- a **desync**. BeaverBuddies addresses each of these through `DeterminismService` and a collection of Harmony patches.
+
+## DeterminismService
+
+**File:** `BeaverBuddies/DeterminismService.cs`
+
+`DeterminismService` is the central coordinator for all determinism enforcement. It is a `RegisteredSingleton` bound during game scene configuration.
+
+### RNG Seeding
+
+Both server and client must start with identical RNG state. The static method `InitGameStartState(byte[] mapBytes)` computes a hash of the save file bytes and uses it to seed Unity's random number generator:
+
+```csharp
+public static void InitGameStartState(byte[] mapBytes)
+{
+    int state = 13;
+    for (int i = 0; i < mapBytes.Length; i++)
+    {
+        state = TimberNetBase.CombineHash(state, mapBytes[i]);
+    }
+    // Stores the seed; applied when DeterminismService is constructed
+    nextSeedOnLoad = state;
+}
+```
+
+The seed is stored in `nextSeedOnLoad` and applied via `UnityEngine.Random.InitState()` when the `DeterminismService` constructor runs during scene load. Both server (`ServerHostingUtils.LoadAndHost`) and client (`ClientConnectionService.LoadMap`) call `InitGameStartState` with identical map bytes before loading, guaranteeing the same initial RNG state.
+
+### Removing Non-Deterministic Singletons from the Tick Loop
+
+Many Timberborn systems use `UpdateSingleton()` to run logic every frame. Some of these consume random numbers for non-gameplay purposes (sound effects, UI previews, analytics). BeaverBuddies intercepts these with Harmony patches that mark them as "non-game" code:
+
+| Patcher Class | Target | Purpose |
+|---|---|---|
+| `InputPatcher` | `InputService.UpdateSingleton` | Input processing uses RNG |
+| `SoundsPatcher` | `Sounds.GetRandomSound` | Sound selection |
+| `SoundEmitterPatcher` | `SoundEmitter.Update` | Sound playback |
+| `DateSalterPatcher` | `DateSalter.GenerateRandomNumber` | Analytics salting |
+| `PlantableDescriberPatcher` | `PlantableDescriber.GetPreviewFromTemplate` | UI preview generation |
+| `StockpileGoodPileVisualizerPatcher` | `StockpileGoodPileVisualizer.Awake` | Visual randomization |
+| `RecoveredGoodStackFactoryPatcher` | `RecoveredGoodStackFactory.RandomizeRotation` | Visual randomization |
+| `LoopingSoundPlayerPatcher` | `LoopingSoundPlayer.PlayLooping` | Audio looping |
+| `BotManufactoryAnimationControllerPatcher` | `BotManufactoryAnimationController.ResetRingRotation` | Animation |
+| `TerrainBlockRandomizerPickVariationPatcher` | `TerrainBlockRandomizer.PickVariation` | Terrain visuals |
+| `BeaverTextureSetterStartPatcher` | `BeaverTextureSetter.Start` | Beaver appearance |
+
+Each patcher calls `DeterminismService.SetNonGamePatcherActive(type, true)` in its `Prefix` and `false` in its `Postfix`. While any non-game patcher is active, `ShouldFreezeSeed` returns `true`, diverting RNG calls to a separate `System.Random` instance that does not affect the game's deterministic state.
+
+### NonTickRandomNumberGenerator
+
+For a more comprehensive approach, `ParameterProviderPatch` intercepts Bindito's dependency injection. When a class in the `blacklist` (e.g., `BeaverTextureSetter`, `GameMusicPlayer`, `Sounds`) requests an `IRandomNumberGenerator`, it receives a `NonTickRandomNumberGenerator` wrapper instead. This wrapper calls `DeterminismService.GetNonGameRandom()` around every RNG operation, ensuring these classes never touch the gameplay RNG.
+
+### ShouldFreezeSeed Logic
+
+The `ShouldFreezeSeed` property determines whether the current random call should use the non-game RNG:
+
+1. If `EventIO.IsNull` (not in multiplayer): return `false` -- no freezing needed.
+2. If `IsNonGameplay` flag is set: return `true`.
+3. If the game is still loading (`!ReplayService.IsLoaded`): return `false` -- loading RNG is gameplay-critical.
+4. If on a non-Unity thread: return `true` -- background threads should not touch game RNG.
+5. If any non-game patchers are active: return `true`.
+6. If currently ticking (`IsTicking`): return `false` -- tick logic is gameplay.
+7. If replaying events (`ReplayService.IsReplayingEvents`): return `false`.
+8. Otherwise: log a warning and return `true` (assume non-game).
+
+### GUID Determinism
+
+`GuidPatcher` patches `Guid.NewGuid()` to generate GUIDs using Unity's (seeded) random number generator instead of the system's cryptographic RNG. This ensures entity IDs are identical on both machines. The method `GenerateWithUnityRandom()` fills 16 bytes from `UnityEngine.Random.Range`.
+
+### Time.time Determinism
+
+`TimeTimePatcher` patches `Time.time` to return a deterministic value based on `ticksSinceLoad * Time.fixedDeltaTime`, removing frame-rate-dependent variation.
+
+### Entity Instantiation
+
+`EntityComponentInstantiatePatcher` ensures that when entities are created, ticking is interrupted (`TickingService.ShouldInterruptTicking = true`) so the new entity's `Start()` runs before the next bucket ticks. It also guards against duplicate GUIDs.
+
+### DayNightCycle Fix
+
+`DayNightCycleFluidSecondsPassedTodayPatcher` removes the frame-interpolated `_secondsPassedThisTick` from the day/night cycle calculation, making it purely tick-based.
+
+### Save Determinism
+
+`GameSaverSavePatcher` ensures saves only happen after a full tick completes by calling `TickingService.FinishFullTickAndThen()`, preventing saves mid-tick that could capture inconsistent state.
+
+## Fixes Directory
+
+The `BeaverBuddies/Fixes/` directory contains targeted patches for specific determinism problems.
+
+### AnimationFixes.cs
+
+**Problem:** `MovementAnimator.Update()` uses `Time.time` to interpolate character positions. Since rendering happens at different rates on different machines, character positions would diverge.
+
+**Solution:** `AnimatedPathFollowerUpdatePatcher` replaces the original `Update` method. Instead of using real `Time.time`, it calculates an interpolated time based on the `TickProgressService`:
+
+```csharp
+time = tickProgressService.TimeAtLastTick(entity) +
+    Time.fixedDeltaTime * tickProgressService.PercentTicked(entity);
+```
+
+This makes animations tick-based while still appearing smooth between ticks. Before each tick, `TEBPatcher` resets animated positions to match the deterministic `PathFollower` position, ensuring the tick starts from a known state.
+
+### WaterSourceFix.cs (LateTickableBuffer)
+
+**Problem:** `WaterSource.Tick()` executes during the parallel tick phase, where execution order across threads is non-deterministic.
+
+**Solution:** `LateTickableBuffer` intercepts `WaterSource.Tick()` calls during the parallel phase and buffers them. After `TickableSingletonService.FinishParallelTick()` completes, the buffered ticks execute sequentially on the main thread:
+
+```csharp
+[HarmonyPatch(typeof(TickableSingletonService),
+    nameof(TickableSingletonService.FinishParallelTick))]
+class TickableSingletonServiceFinishParallelTickPatcher
+{
+    public static void Postfix()
+    {
+        var buffer = SingletonManager.GetSingleton<LateTickableBuffer>();
+        buffer?.TickComponents();
+    }
+}
+```
+
+The `LateTickableBuffer.TickingLate` property tracks whether the buffer is actively ticking, so the `WaterSource.Tick` prefix knows when to allow the original method through.
+
+### WaterWheelFix.cs
+
+**Problem:** `MechanicalNodeFacingMarkerDrawer.GetTransput()` can throw exceptions during UI rendering when water wheel transput calculations encounter edge cases.
+
+**Solution:** A Harmony patch wraps the call in a try/catch, returning `null` on failure. This is a UI-only fix that prevents crashes without affecting determinism.
+
+### TickOnlyArrayFix.cs
+
+**Problem:** `TickOnlyArrayService.AllowEdit` returns `false` outside of tick execution. During deterministic saves, code needs to read from tick-only arrays, but the API conflates read and write permission.
+
+**Solution:** `TickOnlyArrayServiceAllowEditPatch` returns `true` when `GameSaveHelper.IsSavingDeterministically` or `GameSaverSavePatcher.IsSaving` is active, allowing array access during save operations.
+
+## Desync Detection
+
+The `BeaverBuddies/DesyncDetecter/` directory implements two levels of desync detection.
+
+### RNG State Check (Lightweight)
+
+Every `ReplayEvent` carries an optional `randomS0Before` field -- the `s0` component of Unity's RNG state at the time the event was recorded. When the other side replays the event, `ReplayService` compares its current `s0` to the recorded value:
+
+```csharp
+if (!Settings.Debug && replayEvent.randomS0Before != null)
+{
+    int s0 = UnityEngine.Random.state.s0;
+    int randomS0Before = (int)replayEvent.randomS0Before;
+    if (s0 != randomS0Before)
+    {
+        Plugin.LogWarning($"Random state mismatch: {s0:X8} != {randomS0Before:X8}");
+        HandleDesync();
+        break;
+    }
+}
+```
+
+This lightweight check catches most desyncs without the overhead of full tracing. It is always active (when not in Debug mode, which uses the more detailed trace system instead).
+
+### DesyncDetecterService (Detailed Tracing)
+
+When `Settings.Debug` (or `Settings.TemporarilyDebug`) is enabled, `DesyncDetecterService` records a detailed per-tick trace of game events.
+
+**Key types:**
+
+- **`Trace`** -- a serializable struct with `message` (what happened) and `stackTrace` (where it happened).
+- **`DesyncDetecterService`** -- static service that maintains a rolling buffer of traces (up to `maxTraceTicks = 10` ticks of history).
+
+**Workflow:**
+
+1. `StartTick(int tick)` is called from `ReplayService` at the start of each tick, creating a new trace list.
+2. Throughout the tick, `Trace(string message)` is called from various Harmony patches to record significant events.
+3. At the end of each tick, `CreateReplayEventsAndClear()` packages traces into `TraceLoggedForTickEvent` events, which are sent from server to client.
+4. On the client, `TraceLoggedForTickEvent.Replay()` calls `VerifyTraces()` to compare the server's traces against the client's.
+5. If a mismatch is found, `VerifyTraces` builds a detailed log showing shared history, the point of divergence, and both sides' traces at that point.
+
+### TraceLoggedForTickEvent
+
+This `ReplayEvent` subclass carries a tick number and a list of `Trace` objects. Note that `tick` refers to the tick being traced, while `ticksSinceLoad` (inherited from `ReplayEvent`) refers to when the event was actually sent (usually one tick later).
+
+### DesyncPatches
+
+**File:** `BeaverBuddies/DesyncDetecter/DesyncPatches.cs`
+
+This file contains Harmony patches that add trace points to critical game systems. These are only active when `Settings.Debug` is true:
+
+| Patch | What It Traces |
+|---|---|
+| `NRPMarkSpotsPatcher` | `NaturalResourceReproducer.MarkSpots` -- resource reproduction spot tracking |
+| `NRPUnmarkSpotsPatcher` | `NaturalResourceReproducer.UnmarkSpots` -- spot removal |
+| `SpawnValidationServiceCanSpawnPatcher` | Whether a resource can spawn at given coordinates |
+| `NRRPatcher` | `NaturalResourceReproducer.SpawnNewResources` -- actual spawning |
+| `WalkerFindPathPatcher` | `Walker.FindPath` -- beaver pathfinding decisions |
+| `NaturalResourceModelRandomizerPatcher` | Diameter scale randomization |
+| `WalkToReservableExecutorPatcher` | Reservable walking targets |
+| `WateredNaturalResourceStartDryingOutPatcher` | Drying-out timer creation |
+| `SoilMoistureMapSetMoistureLevelPatcher` | Soil moisture level hashes |
+| `ThreadSafeWaterMapUpdateDataPatcher` | Water map column and count hashes |
+| `TEBAddPatcher` | Entity additions to tick buckets |
+
+## Common Desync Causes
+
+Based on the development notes in `DeterminismService.cs`, these are the most common causes of desync:
+
+1. **Non-saved random initialization** -- Components like `WateredNaturalResource.Awake()` use random numbers before the client has received its RNG seed. Fixed by seeding from the map hash.
+
+2. **Floating-point accumulation** -- Movement and time calculations that accumulate small differences over many frames. Fixed by making `Time.time` and animations tick-based.
+
+3. **OnDestroyed timing** -- Gameplay code in `OnDestroyed` callbacks can fire at different times on different machines (end of frame vs. during tick).
+
+4. **Parallel tick ordering** -- Systems like water sources that execute during parallel ticks may process in different orders. Fixed by `LateTickableBuffer`.
+
+5. **Frame-dependent updates** -- Any code that runs per-frame rather than per-tick and modifies game state. Fixed by moving `RecoveredGoodStackSpawner.UpdateSingleton` and similar systems to tick-only execution via `TickReplacerService`.
+
+6. **GUID collisions** -- During preloading, newly generated GUIDs could collide with existing save data. Fixed by the collision-check loop in `EntityComponentInstantiatePatcher`.

--- a/docs/event-system.md
+++ b/docs/event-system.md
@@ -1,0 +1,344 @@
+# Event System
+
+This page provides a deep dive into BeaverBuddies' event system -- the mechanism by which all player actions are captured, serialized, transmitted, and replayed across multiplayer clients.
+
+## Core Concept
+
+Every player action that affects game state is intercepted by a Harmony prefix patch and converted into a `ReplayEvent` object. These events are serialized to JSON, sent over the network (or written to a file), and replayed on all participants. Because the Timberborn simulation is deterministic, applying the same sequence of events to the same starting save produces identical game states on all clients.
+
+The event lifecycle:
+
+1. Player performs an action (e.g., places a building)
+2. Harmony prefix intercepts the game method call
+3. A `ReplayEvent` is created with the relevant parameters
+4. The event is passed to `ReplayService.RecordEvent()`
+5. Depending on `UserEventBehavior`, the original method either executes or is cancelled
+6. Events are transmitted via `EventIO` to all participants
+7. On the receiving side, `ReplayEvent.Replay()` is called to execute the action
+
+## ReplayEvent Base Class
+
+**File:** `BeaverBuddies/Events/ReplayEvent.cs`
+
+All events inherit from the abstract `ReplayEvent` class:
+
+```csharp
+public abstract class ReplayEvent : IComparable<ReplayEvent>
+{
+    public int ticksSinceLoad;      // The tick number when this event occurred
+    public int? randomS0Before;     // RNG state before the event (for desync detection)
+    public string type => GetType().Name;  // Serialized type name for debugging
+
+    public abstract void Replay(IReplayContext context);
+}
+```
+
+### Key Fields
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `ticksSinceLoad` | `int` | Tick counter at event creation. Used to order events and ensure they replay at the correct tick. |
+| `randomS0Before` | `int?` | Snapshot of the random number generator seed before the event. Used by `DeterminismService` to detect desyncs. |
+| `type` | `string` | The class name of the event (read-only property). Included in JSON for debugging. |
+
+### IReplayContext
+
+Events access game services through `IReplayContext`, which provides a `GetSingleton<T>()` method. This is implemented by `ReplayService` and allows events to look up any registered Timberborn service (e.g., `EntityRegistry`, `BlockObjectPlacerService`, `SpeedManager`).
+
+### Helper Methods
+
+`ReplayEvent` provides static helpers used throughout the event classes:
+
+- **`GetEntityComponent(context, entityID)`** -- Looks up an entity by its GUID string via `EntityRegistry`
+- **`GetComponent<T>(context, entityID)`** -- Gets a typed component from an entity
+- **`GetEntityID(component)`** -- Extracts the GUID string from a `BaseComponent`
+- **`GetBuilding(context, buildingName)`** -- Looks up a `BuildingSpec` by template name
+
+### The DoPrefix Flow
+
+The `DoPrefix` static method is the standard pattern used by all Harmony prefix patches to intercept game methods:
+
+```csharp
+public static bool DoPrefix(Func<ReplayEvent> getEvent)
+{
+    // 1. If already replaying events, let the original method run
+    if (ReplayService.IsReplayingEvents) return true;
+
+    // 2. If ReplayService is unavailable (no co-op), use default behavior
+    ReplayService replayService = GetReplayServiceIfReady();
+    if (replayService == null) return true;
+
+    // 3. Create the event; if null, use default behavior
+    ReplayEvent message = getEvent();
+    if (message == null) return true;
+
+    // 4. Record the event with ReplayService
+    replayService.RecordEvent(message);
+
+    // 5. Return based on whether this side should execute the action
+    return EventIO.ShouldPlayPatchedEvents;
+}
+```
+
+The return value controls whether the original game method executes:
+- **Server (`QueuePlay`)**: Returns `false` -- the action is queued and will execute on the next tick during replay
+- **Client (`Send`)**: Returns `false` -- the action is sent to the server; it will execute when received back
+- **Replay**: Returns `true` -- during `ReplayService`'s event replay loop, `IsReplayingEvents` is true, so the original method runs normally
+
+### DoEntityPrefix
+
+A convenience wrapper for entity-scoped events:
+
+```csharp
+public static bool DoEntityPrefix(BaseComponent component, Func<string, ReplayEvent> doRecord)
+```
+
+This extracts the entity GUID from the component and passes it to the event creation function. If the component has no `EntityComponent` (e.g., it is a prefab), it returns `true` to let the default behavior run without recording.
+
+## Event Categories
+
+### ToolEvents.cs -- Building, Demolition, Planting, Zoning
+
+**File:** `BeaverBuddies/Events/ToolEvents.cs`
+
+This is the largest event file, covering all spatial tool interactions:
+
+| Event Class | Patched Method | Description |
+|-------------|---------------|-------------|
+| `BuildingPlacedEvent` | `BuildingPlacer.Place` | Places a building at specific coordinates with orientation, flip mode, and optional duplication source |
+| `BuildingsDeconstructedEvent` | `BlockObjectDeletionTool.DeleteBlockObjects` | Deletes one or more buildings by entity ID |
+| `PlantingAreaMarkedEvent` | `PlantingSelectionService.MarkArea` / `UnmarkArea` | Marks or unmarks an area for planting a specific tree/crop |
+| `ClearResourcesMarkedEvent` | `DemolishableSelectionTool.ActionCallback` | Marks or unmarks resources (trees, ruins) for demolition |
+| `TreeCuttingAreaEvent` | `TreeCuttingArea.AddCoordinates` / `RemoveCoordinates` | Adds or removes coordinates from tree-cutting zones |
+| `BuildingUnlockedEvent` | `BuildingUnlockingService.Unlock` | Unlocks a building via the science system, including tool button unlocking |
+
+**BuildingPlacedEvent** is notable for its complexity. It stores:
+- `prefabName` -- the building template name
+- `coordinates` -- `Vector3Int` grid position
+- `orientation` -- rotation enum
+- `isFlipped` -- flip state
+- `duplicationSourceID` -- if the building was placed by duplicating another, this references the source entity so settings can be copied via `Duplicator.Duplicate()`
+
+On replay, it validates the placement by instantiating a temporary preview object and checking `BlockObject.IsValid()` before actually placing.
+
+### TimeEvents.cs -- Speed Control
+
+**File:** `BeaverBuddies/Events/TimeEvents.cs`
+
+| Event Class | Patched Method | Description |
+|-------------|---------------|-------------|
+| `SpeedSetEvent` | `SpeedManager.ChangeSpeed` | Sets game speed to a specific value |
+| `ShowOptionsMenuEvent` | `GameOptionsBox.Show` | Pauses game and shows options (extends `SpeedSetEvent` with speed=0) |
+
+The `SpeedChangePatcher` patches `SpeedManager.ChangeSpeed` directly (rather than using `DoPrefix`) because it needs special handling:
+- It skips recording if the speed is already at the target value
+- It has a `silently` flag for internal speed changes that should not generate events
+- If the client is out of events (`ShouldPauseTicking`), it overrides the requested speed to 0
+
+Additional patchers (`SpeedLockPatcher`, `SpeedUnlockPatcher`) handle dialog-triggered speed locks. Clients skip these entirely since only the host should freeze for dialogs.
+
+### SystemEvents.cs -- Autosave
+
+**File:** `BeaverBuddies/Events/SystemEvents.cs`
+
+| Event Class | Description |
+|-------------|-------------|
+| `AutosaveEvent` | Defers autosaves to ensure they happen at consistent tick boundaries |
+
+The autosave patcher is currently commented out in the source, but the event class remains. When active, it ensures that autosaves triggered by the game's timer are synchronized -- the client should never autosave independently, and the server defers non-instant saves through the event system.
+
+### ConnectionEvents.cs -- Initialization and Desync Handling
+
+**File:** `BeaverBuddies/Events/ConnectionEvents.cs`
+
+| Event Class | Description |
+|-------------|-------------|
+| `InitializeClientEvent` | Sent by the server on connection to validate version compatibility |
+| `ClientDesyncedEvent` | Triggered when a desync is detected; handles UI, reporting, and recovery |
+
+**InitializeClientEvent** carries three fields for validation:
+- `serverModVersion` -- compared against the client's `Plugin.Version`
+- `serverGameVersion` -- compared against `GameVersions.CurrentVersion`
+- `isDebugMode` -- compared against `Settings.Debug`
+
+If any mismatch is found, a warning dialog is shown to the player.
+
+**ClientDesyncedEvent** is one of the most complex events. On replay it:
+1. Pauses the game (`SetTargetSpeed(0)`)
+2. Shows a dialog with up to three options:
+   - **Report bug** -- if debug tracing is enabled, uploads the desync trace and save file via `ReportingService`; if not, offers to enable tracing
+   - **Reconnect/Rehost** -- the host can save and rehost; the client can attempt to reconnect
+   - **Cancel** -- dismiss the dialog
+3. Handles user consent for data reporting via `Settings.ReportingConsent`
+
+### EntityUIEvents.cs -- Entity Panel Interactions
+
+**File:** `BeaverBuddies/Events/EntityUIEvents.cs`
+
+This file handles all UI interactions on individual entities (buildings, characters):
+
+| Event Class | Patched Method | Description |
+|-------------|---------------|-------------|
+| `GatheringPrioritizedEvent` | `GatherablePrioritizer.PrioritizeGatherable` | Sets gathering priority for a building |
+| `ManufactoryRecipeSelectedEvent` | `Manufactory.SetRecipe` | Selects a recipe for a workshop |
+| `BuildingDropdownEvent<T>` | (abstract base) | Generic base for dropdown-style selections on buildings |
+
+These events follow a common pattern using the abstract `BuildingDropdownEvent<Selector>` base class:
+
+```csharp
+abstract class BuildingDropdownEvent<Selector> : ReplayEvent where Selector : BaseComponent
+{
+    public string itemID;    // The selected item (recipe name, resource name, etc.)
+    public string entityID;  // The target building's GUID
+
+    public override void Replay(IReplayContext context)
+    {
+        var selector = GetComponent<Selector>(context, entityID);
+        if (selector == null) return;
+        SetValue(context, selector, itemID);
+    }
+
+    protected abstract void SetValue(IReplayContext context, Selector selector, string id);
+}
+```
+
+The file also includes numerous other entity interaction events for work scheduling, priority setting, naming, emptying, inventory management, and more. Each follows the standard `DoEntityPrefix` pattern.
+
+### AutomationEvents.cs -- Automation Component Interactions
+
+**File:** `BeaverBuddies/Events/AutomationEvents.cs`
+
+The automation system uses a **reflection-based approach** rather than individual event classes per action. A single `AutomationEvent` class handles all automation component interactions:
+
+```csharp
+public class AutomationEvent : ReplayEvent
+{
+    public string entityID;      // Target entity GUID
+    public string methodKey;     // "FullClassName.MethodName" lookup key
+    public object[] arguments;   // Serialized method arguments
+}
+```
+
+**How it works:**
+
+1. `ApplyAutomationPatches(Harmony)` is called at startup with a list of `(Type, string)` tuples specifying which methods to patch
+2. For each method, it registers a `UniversalPrefix` as the Harmony prefix and caches the `MethodInfo` in a dictionary keyed by `"ClassName.MethodName"`
+3. When any patched method is called, `UniversalPrefix` creates an `AutomationEvent` with the method key and serialized arguments
+4. On replay, `Replay()` looks up the `MethodInfo` from the cache, resolves the target component via reflection (`GetComponent` with a runtime type), deserializes the arguments, and invokes the method
+
+The list of patched methods covers the full automation system:
+
+- **Chronometer** -- `SetStartTime`, `SetEndTime`, `SetMode`
+- **Sensors** -- `ContaminationSensor`, `DepthSensor`, `FlowSensor` (mode and threshold setters)
+- **FireworkLauncher** -- `SetContinuous`, `SetFireworkId`, `SetFlightDistance`, `SetHeading`, `SetPitch`
+- **Logic components** -- `Gate.SetOpeningMode`, `Indicator` settings, `Lever` (pin, spring return, switch), `Memory` (mode, inputs), `Relay` (inputs, mode)
+- **Counters** -- `PopulationCounter`, `PowerMeter`, `ResourceCounter`, `ScienceCounter` (various setters)
+- **Other** -- `Speaker`, `Timer`, `WeatherStation`
+
+The arguments go through a `Serialize`/`Deserialize` step to handle types that need special conversion (e.g., entity references are converted to GUID strings).
+
+### BatchEvents.cs -- District Migration and Population
+
+**File:** `BeaverBuddies/Events/BatchEvents.cs`
+
+| Event Class | Patched Method | Description |
+|-------------|---------------|-------------|
+| `ManualMigrationEvent` | `ManualMigrationPopulationRow.MigratePopulation` | Moves beavers/bots between districts |
+| `SetDistrictMinimumPopulationEvent` | `PopulationDistributor.SetMinimumAndMigrate` | Sets minimum population for a district |
+| `SetDistrictMigrationToggledEvent` | `PopulationDistributor.ToggleAllowImmigrationAndMigrate` / `ToggleAllowEmigrationAndMigrate` | Toggles immigration/emigration for a district |
+
+These events use a `DistributorType` enum to identify the population category:
+
+```csharp
+enum DistributorType
+{
+    Children,
+    Adults,
+    Bots,
+    Contaminated,
+    Unknown
+}
+```
+
+The `DistributorUtils` helper class maps between `IDistributorTemplate` instances and the enum, and retrieves the appropriate `PopulationDistributor` from a `DistrictCenter`.
+
+## Special Events
+
+### GroupedEvent
+
+**File:** `BeaverBuddies/ReplayService.cs`
+
+```csharp
+class GroupedEvent : ReplayEvent
+{
+    public List<ReplayEvent> events;
+}
+```
+
+A `GroupedEvent` wraps multiple events that belong to the same tick. This ensures that when events are transmitted over the network, all events for a given tick arrive together. The receiving side unpacks the group and replays each event individually. `GroupedEvent.Replay()` throws `NotImplementedException` because it should never be replayed directly -- the `ReplayService` handles unpacking.
+
+### HeartbeatEvent
+
+**File:** `BeaverBuddies/ReplayService.cs`
+
+```csharp
+class HeartbeatEvent : ReplayEvent
+{
+    public override void Replay(IReplayContext context)
+    {
+        // No op
+    }
+}
+```
+
+The server sends a `HeartbeatEvent` at the end of each tick. This signals to clients that the server has completed that tick and they may advance. Without a heartbeat, clients pause and wait -- this is what keeps server and clients in lockstep. The heartbeat is a no-op when replayed; its presence in the event stream is what matters.
+
+## JSON Serialization
+
+**File:** `BeaverBuddies/IO/FileIO.cs`
+
+All events are serialized using Newtonsoft.Json with custom settings defined in the `JsonSettings` class:
+
+```csharp
+class JsonSettings : JsonSerializerSettings
+{
+    public JsonSettings()
+    {
+        Formatting = Formatting.Indented;
+        TypeNameHandling = TypeNameHandling.All;
+        Converters.Add(new Vector3Converter());
+        Converters.Add(new Vector3IntConverter());
+    }
+}
+```
+
+### Key Configuration
+
+| Setting | Value | Purpose |
+|---------|-------|---------|
+| `TypeNameHandling` | `TypeNameHandling.All` | Embeds the full .NET type name (`$type`) in every JSON object. This enables polymorphic deserialization -- the deserializer can reconstruct the correct `ReplayEvent` subclass from the JSON without knowing the type in advance. |
+| `Formatting` | `Formatting.Indented` | Human-readable output for debugging. |
+
+### Custom Converters
+
+Unity's `Vector3` and `Vector3Int` types do not serialize cleanly with default JSON settings, so custom converters are provided:
+
+- **`Vector3Converter`** -- Serializes `Vector3` as a JSON array `[x, y, z]` of floats
+- **`Vector3IntConverter`** -- Serializes `Vector3Int` as a JSON array `[x, y, z]` of integers
+
+### Serialization in Network Transport
+
+In `NetIOBase<T>`, events are serialized to `JObject` for transmission over TimberNet:
+
+```csharp
+private static ReplayEvent ToEvent(JObject obj)
+{
+    return JsonSettings.Deserialize<ReplayEvent>(obj.ToString());
+}
+```
+
+The `WriteEvents` method serializes events to JSON and passes them to TimberNet, which handles GZip compression at the transport layer. The `ReadEvents` method deserializes received `JObject` instances back into typed `ReplayEvent` subclasses using the `$type` metadata from `TypeNameHandling.All`.
+
+### File-Based Serialization
+
+`FileWriteIO` writes events as a JSON array to disk for replay recording. `FileReadIO` reads the array back and uses `TimberNetBase.PopEventsForTick()` to return events matching the current tick during playback.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,132 @@
+# Getting Started
+
+This guide walks you through setting up a development environment for BeaverBuddies.
+
+## Prerequisites
+
+- **Timberborn** - The base game (Steam or other distribution)
+- **Visual Studio 2022** - [Community Edition](https://visualstudio.microsoft.com/downloads/) (free)
+- **BepInEx v5.4.22** - [Download here](https://github.com/BepInEx/BepInEx/releases/tag/v5.4.22)
+- **ModSettings mod** - Required dependency ([Steam Workshop](https://steamcommunity.com/sharedfiles/filedetails/?id=3283831040))
+
+## Step 1: Install BepInEx
+
+1. Download the correct BepInEx zip for your platform from the link above
+2. Extract the contents into your Timberborn game folder:
+   - **Windows:** `C:\Program Files (x86)\Steam\steamapps\common\Timberborn\`
+   - **macOS:** `~/Library/Application Support/Steam/steamapps/common/Timberborn/`
+3. Run Timberborn once to finish BepInEx installation. If successful, you'll see a `config` folder inside `BepInEx/`
+
+**Recommended:** Enable console logging for debugging by editing `BepInEx/config/BepInEx.cfg`:
+
+```ini
+[Logging.Console]
+
+## Enables showing a console for log output.
+# Setting type: Boolean
+# Default value: false
+Enabled = true
+```
+
+## Step 2: Clone and Configure
+
+1. Clone the repository:
+
+```bash
+git clone https://github.com/matthewwachter/BeaverBuddies.git
+cd BeaverBuddies
+```
+
+2. Open `BeaverBuddies.sln` in Visual Studio 2022
+
+3. On first build, `env.props` is automatically created from the platform template. If needed, copy it manually:
+   - **Windows:** Copy `env.props.windows-template` to `env.props`
+   - **macOS/Linux:** Copy `env.props.unix-template` to `env.props`
+
+4. Edit `BeaverBuddies/env.props` to match your system paths:
+
+**Windows:**
+
+```xml
+<Project>
+  <PropertyGroup>
+    <!-- All paths must end with a slash -->
+    <TimberbornDataPath>C:\Program Files (x86)\Steam\steamapps\common\Timberborn\Timberborn_Data\</TimberbornDataPath>
+    <BepInExPath>C:\Dev\BepInEx\</BepInExPath>
+    <ModSettingsPath>C:\Program Files (x86)\Steam\steamapps\workshop\content\1062090\3283831040\version-0.7\Scripts\</ModSettingsPath>
+    <DocumentsPath>C:\Users\YourName\Documents\</DocumentsPath>
+  </PropertyGroup>
+</Project>
+```
+
+**macOS:**
+
+```xml
+<Project>
+  <PropertyGroup>
+    <TimberbornDataPath>$(HOME)/Library/Application Support/Steam/steamapps/common/Timberborn/Timberborn.app/Contents/Resources/Data/</TimberbornDataPath>
+    <BepInExPath>$(HOME)/dev/BepInEx/BepInEx/</BepInExPath>
+    <ModSettingsPath>$(HOME)/Documents/Timberborn/Mods/modsettings-ey0f/version-1.0/Scripts/</ModSettingsPath>
+    <DocumentsPath>$(HOME)/Documents/</DocumentsPath>
+  </PropertyGroup>
+</Project>
+```
+
+### Path Reference
+
+| Property | Description |
+|----------|-------------|
+| `TimberbornDataPath` | Points to the game's `Timberborn_Data/` (or equivalent on macOS) directory |
+| `BepInExPath` | Root BepInEx directory containing `core/` with Harmony DLLs |
+| `ModSettingsPath` | ModSettings mod `Scripts/` directory containing its DLLs |
+| `DocumentsPath` | User documents folder where `Timberborn/Mods/` lives |
+
+## Step 3: Build
+
+Build the project with `Ctrl+Shift+B` (or `dotnet build` from the command line).
+
+On successful build, the post-build step automatically copies the mod files to:
+
+```
+Documents/Timberborn/Mods/BeaverBuddies/
+```
+
+This includes the compiled DLL, manifest, localizations, and thumbnail.
+
+## Step 4: Run
+
+1. Launch Timberborn
+2. On the mod selection screen, enable the **BeaverBuddies** mod
+3. Start or load a game
+
+## Build Configurations
+
+| Configuration | Description |
+|---------------|-------------|
+| **Debug** | Standard debug build with symbols |
+| **Release** | Optimized release build |
+| **Debug Steam** | Debug build with `IS_STEAM` defined - includes Steam P2P networking |
+| **Release Steam** | Release build with `IS_STEAM` defined |
+
+The `IS_STEAM` conditional compilation symbol enables Steam-specific code paths (P2P networking, lobby system, overlay integration). Non-Steam builds only support direct TCP connections.
+
+## Solution Structure
+
+The solution contains four projects:
+
+| Project | Type | Description |
+|---------|------|-------------|
+| **BeaverBuddies** | .NET Standard 2.1 Library | Main mod - BepInEx plugin with all game patches and multiplayer logic |
+| **TimberNet** | .NET Standard 2.1 Library | Standalone networking library (TCP/Steam transport, message framing) |
+| **ClientServerSimulator** | Windows Forms App | Testing tool for simulating client/server communication |
+| **Inspector** | Console App | Utility tools (localization updates, etc.) |
+
+## Key Dependencies
+
+- **BepInEx.AssemblyPublicizer.MSBuild** - Makes private Timberborn fields/methods accessible at compile time
+- **Timberborn DLLs** - Referenced from game installation (publicized for access to internals)
+- **Bindito** - Timberborn's dependency injection framework
+- **HarmonyX** - Runtime method patching for intercepting game logic
+- **Steamworks.NET** - Steam API wrapper (Steam builds only)
+- **Newtonsoft.Json** - JSON serialization (included via TimberNet)
+- **System.Collections.Immutable** - Immutable collections (NuGet)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -130,3 +130,25 @@ The solution contains four projects:
 - **Steamworks.NET** - Steam API wrapper (Steam builds only)
 - **Newtonsoft.Json** - JSON serialization (included via TimberNet)
 - **System.Collections.Immutable** - Immutable collections (NuGet)
+
+## Previewing Documentation
+
+The documentation site in `docs/` uses [Docsify](https://docsify.js.org/). To preview it locally:
+
+**Option 1: docsify-cli (recommended)**
+
+```bash
+npm install -g docsify-cli
+docsify serve docs
+```
+
+Then open `http://localhost:3000`.
+
+**Option 2: Python**
+
+```bash
+cd docs
+python -m http.server 8000
+```
+
+Then open `http://localhost:8000`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>BeaverBuddies - Developer Documentation</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify@4/lib/themes/dark.css">
+    <style>
+        /* Fix table row backgrounds for dark theme */
+        .markdown-section table tr {
+            background-color: transparent;
+        }
+        .markdown-section table tr:nth-child(2n) {
+            background-color: rgba(255, 255, 255, 0.05);
+        }
+        .markdown-section table td, .markdown-section table th {
+            border-color: rgba(255, 255, 255, 0.12);
+        }
+
+        /* Brighter bold text for dark theme */
+        .markdown-section strong {
+            color: #e8e8e8;
+        }
+
+        /* Brighten code block text for dark theme */
+        .markdown-section code[class*="language-"],
+        .markdown-section pre[class*="language-"] {
+            color: #c8ccd4;
+        }
+        .token.punctuation {
+            color: #abb2bf;
+        }
+        .token.operator {
+            color: #c678dd;
+        }
+        .token.class-name {
+            color: #e5c07b;
+        }
+        .token.function {
+            color: #61afef;
+        }
+        .token.keyword {
+            color: #c678dd;
+        }
+        .token.string {
+            color: #98c379;
+        }
+        .token.comment {
+            color: #7f848e;
+        }
+        .token.number {
+            color: #d19a66;
+        }
+        .markdown-section pre,
+        .markdown-section pre code {
+            color: #c8ccd4;
+        }
+        .markdown-section code {
+            color: #e06c75;
+            background-color: rgba(255, 255, 255, 0.08);
+        }
+
+        /* Sidebar toggle: move to top-left, above sidebar's stacking context */
+        .sidebar-toggle {
+            bottom: auto;
+            top: 12px;
+            z-index: 30;
+        }
+
+        /* Sticky search bar below toggle, with background so nav scrolls under */
+        .sidebar .search {
+            position: sticky;
+            top: 0;
+            z-index: 4;
+            background-color: inherit;
+            padding-top: 3.5rem;
+        }
+    </style>
+</head>
+<body>
+    <div id="app"></div>
+    <script>
+        window.$docsify = {
+            name: 'BeaverBuddies',
+            repo: 'https://github.com/matthewwachter/BeaverBuddies',
+            loadSidebar: true,
+            subMaxLevel: 3,
+            auto2top: true,
+            search: {
+                placeholder: 'Search docs...',
+                noData: 'No results.',
+                depth: 6
+            }
+        };
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/docsify@4"></script>
+    <script src="https://cdn.jsdelivr.net/npm/docsify@4/lib/plugins/search.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/docsify-copy-code@2"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-python.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-bash.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-json.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-csharp.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1/components/prism-xml-doc.min.js"></script>
+</body>
+</html>

--- a/docs/multiplayer-maps.md
+++ b/docs/multiplayer-maps.md
@@ -1,0 +1,250 @@
+# Multiplayer Maps
+
+BeaverBuddies supports maps with multiple starting locations, allowing each player to begin with their own district. This page covers the multi-start system, map editor extensions, and how multiplayer metadata is stored in map files.
+
+## Multiple Starting Locations
+
+In standard Timberborn, each map has a single starting location where all initial buildings and beavers spawn. BeaverBuddies extends this so a map can have up to 4 starting locations, one per player.
+
+When a multiplayer map loads:
+
+1. Each starting location spawns its own set of starting buildings.
+2. Each starting location spawns its own set of beavers.
+3. The camera centers on the first player's location.
+4. Players share the same game world but begin in separate areas.
+
+If a map has more starting locations than the configured player count, only the first N locations are used (ordered by player index). If a map has only one starting location, the standard single-player behavior is used.
+
+## MultiStart Directory
+
+The `BeaverBuddies/MultiStart/` directory implements the core multi-start gameplay logic.
+
+### StartingLocationPlayer
+
+**File:** `BeaverBuddies/Editor/StartingLocationPlayer.cs`
+
+`StartingLocationPlayer` is a component added to starting location entities. It tracks which player owns each location.
+
+**Key fields and constants:**
+
+| Field | Description |
+|---|---|
+| `PlayerIndex` | Integer 0-3 identifying the owning player |
+| `MAX_PLAYERS` | Constant: `4` |
+| `DEFAULT_MAX_STARTING_LOCS` | Constant: `2` |
+| `PLAYER_COLORS` | Array of 4 `Color` values for visual differentiation |
+
+**Player colors:**
+
+| Index | Color Description |
+|---|---|
+| 0 | Warm rose (lightened `#770018`) |
+| 1 | Teal-green (lightened `#00775f`) |
+| 2 | Purple (lightened `#5f0077`) |
+| 3 | Gold (`#f5bd02`) |
+
+The component implements `IPersistentEntity`, saving and loading `PlayerIndex` via the `"StartingLocationPlayer"` component key. On `Start()`, it tints the starting location's renderer materials to the player's color.
+
+A companion record, `StartingLocationPlayerSpec`, extends `ComponentSpec` to carry `PlayerIndex` through the template/blueprint system.
+
+### StartBuildingsService
+
+**File:** `BeaverBuddies/MultiStart/StartBuildingsService.cs`
+
+`StartBuildingsService` is a `RegisteredSingleton` that tracks which buildings were spawned at starting locations.
+
+```csharp
+public class StartBuildingsService : RegisteredSingleton
+{
+    public List<Building> StartingBuildings { get; private set; } = new List<Building>();
+    public bool IsMultiStart => StartingBuildings.Count > 1;
+
+    public int MaxStartLocations()
+    {
+        GameModeSpec newGameMode = ...;
+        if (newGameMode is MultiplayerNewGameModeSpec multiplayerNewGameMode)
+        {
+            return multiplayerNewGameMode.Players;
+        }
+        return StartingLocationPlayer.DEFAULT_MAX_STARTING_LOCS;
+    }
+}
+```
+
+- `RegisterStartingBuilding()` -- Called during initialization for each spawned starting building.
+- `IsMultiStart` -- Returns true when more than one starting building was registered.
+- `MaxStartLocations()` -- Reads the player count from the `MultiplayerNewGameModeSpec` if available, otherwise defaults to `DEFAULT_MAX_STARTING_LOCS` (2).
+
+### MultiplayerNewGameModeSpec
+
+**File:** `BeaverBuddies/MultiStart/MultiplayerNewGameMode.cs`
+
+A record type extending Timberborn's `GameModeSpec` with a `Players` property:
+
+```csharp
+public record MultiplayerNewGameModeSpec : GameModeSpec
+{
+    public int Players { get; init; }
+
+    public MultiplayerNewGameModeSpec(GameModeSpec mode, int players) : base(mode)
+    {
+        Players = players;
+    }
+}
+```
+
+This is created in the new game configuration UI when the player sets the number of starting locations.
+
+### MultiStartPatches
+
+**File:** `BeaverBuddies/MultiStart/MultiStartPatches.cs`
+
+This file contains the Harmony patches that make multi-start work.
+
+#### StartingBuildingInitializerInitializePatcher
+
+Patches `StartingBuildingInitializer.Initialize` to handle multiple starting locations:
+
+1. Retrieves all `StartingLocation` entities from the entity registry.
+2. If only one exists, defers to default behavior.
+3. Orders locations by `StartingLocationPlayer.PlayerIndex`.
+4. For each location (up to `MaxStartLocations`):
+   - Calls `_startingBuildingSpawner.Place()` with that location's placement.
+   - Registers the building with `StartBuildingsService`.
+5. Centers the camera on the first location.
+6. Deletes all starting location markers.
+
+#### GameInitializerSpawnBeaversPatcher
+
+Patches `GameInitializer.SpawnBeavers` to spawn beavers at each starting building rather than just one:
+
+```csharp
+foreach (Building startingBuilding in startBuildingsService.StartingBuildings)
+{
+    Vector3? unblockedSingleAccess = startingBuilding
+        .GetComponent<BuildingAccessible>().Accessible.UnblockedSingleAccess;
+    if (unblockedSingleAccess.HasValue)
+    {
+        __instance._startingBeaverInitializer.Initialize(
+            valueOrDefault, newGameMode.StartingAdults, ...);
+    }
+}
+```
+
+Each starting building gets its own set of adult and child beavers.
+
+#### CustomNewGameModeControllerInitializePatcher
+
+Patches the new game mode customization UI to add a **"Max Starting Locations"** integer field. This field:
+
+- Appears above the "Starting Adults" field.
+- Defaults to `DEFAULT_MAX_STARTING_LOCS` (2).
+- Has a minimum of 1 and maximum of `MAX_PLAYERS` (4).
+- Is styled with bold text.
+- Is stored in the `MultiplayerNewGameModeSpec` when the game mode is created.
+
+#### CustomNewGameModeControllerGetNewGameModePatcher
+
+Patches `CustomNewGameModeController.GetGameMode` to wrap the result in a `MultiplayerNewGameModeSpec` with the selected player count.
+
+#### NewGameModePanel Patches
+
+Two patches (`NewGameModePanelSelectModeButtonPatcher` and `NewGameModePanelSelectFactionAndMapPatcher`) auto-open the customization panel when a multiplayer map is selected, so the player can configure the number of starting locations.
+
+### MultiStartConfigurator
+
+**File:** `BeaverBuddies/MultiStart/MultiStartConfigurator.cs`
+
+Registers the multi-start services with the dependency injection container:
+
+```csharp
+public static void Configure(IContainerDefinition containerDefinition)
+{
+    containerDefinition.Bind<StartBuildingsService>().AsSingleton();
+    containerDefinition.Bind<StartingLocationPlayer>().AsTransient();
+    containerDefinition.MultiBind<TemplateModule>()
+        .ToProvider<TemplateModuleProvider>().AsSingleton();
+}
+```
+
+The `TemplateModuleProvider` adds `StartingLocationPlayer` as a decorator for `StartingLocationSpec`, so every starting location entity automatically gets the player assignment component.
+
+## Map Editor Extensions
+
+The `BeaverBuddies/Editor/` directory extends Timberborn's map editor to support creating multiplayer maps.
+
+### EditorConfigurator
+
+**File:** `BeaverBuddies/Editor/EditorConfigurator.cs`
+
+Registered with the `[Context("MapEditor")]` attribute, this configurator binds:
+
+- `StartingLocationNumberService` -- for managing player numbering.
+- All `MultiStartConfigurator` services -- so starting locations work in the editor.
+
+### StartingLocationNumberService
+
+**File:** `BeaverBuddies/Editor/StartingLocationNumberService.cs`
+
+Manages the ordering and numbering of starting locations in the editor:
+
+- `ResetNumbering()` -- Re-indexes all `StartingLocationPlayer` components sequentially (0, 1, 2, ...) ordered by their current `PlayerIndex`.
+- `GetMaxPlayers()` -- Returns the count of starting locations (minimum 1).
+
+### Map Editor Buttons
+
+`MapEditorButtonsGetElementsPatcher` (in `MapEditorPatches.cs`) replaces the default starting location button with a tool group containing up to `MAX_PLAYERS` (4) individually labeled starting locations:
+
+- "Starting Location 1" through "Starting Location 4"
+- Each carries a `StartingLocationPlayerSpec` with the appropriate `PlayerIndex`.
+- The blueprints are cloned from the original starting location blueprint with modified specs.
+
+### Starting Location Deletion
+
+`StartingLocationServiceDeleteOtherStartingLocationsPatcher` modifies the default behavior that deletes all but one starting location. In multiplayer maps, it only deletes other starting locations with the **same player index**, allowing multiple player-specific locations to coexist.
+
+### Duplication Prevention
+
+`DuplicationValidatorCanDuplicateObjectPatcher` prevents duplicating starting location entities with the duplication tool, since they carry player-specific data.
+
+### MultiplayerMapMetadata
+
+**File:** `BeaverBuddies/Editor/MultiplayerMapMetadata.cs`
+
+Extends Timberborn's `MapMetadata` with a `MaxPlayers` property:
+
+```csharp
+public class MultiplayerMapMetadata : MapMetadata
+{
+    public int MaxPlayers { get; }
+
+    public MultiplayerMapMetadata(MapMetadata metadata, int maxPlayers)
+        : base(metadata.Width, metadata.Height, ...) { ... }
+}
+```
+
+### MultiplayerMapMetadataService
+
+Also in `MultiplayerMapMetadata.cs`, this `RegisteredSingleton` reads multiplayer metadata from map files:
+
+```csharp
+public MultiplayerMapMetadata TryGetMultiplayerMapMetadata(MapFileReference reference)
+{
+    return _mapDeserializer.ReadFromMapFile(reference, _mapMetadataSerializer)
+        as MultiplayerMapMetadata;
+}
+```
+
+Returns `null` for non-multiplayer maps.
+
+### Serialization Patches
+
+Two patches in `MapEditorPatches.cs` handle saving and loading the `MaxPlayers` field:
+
+- `MapMetadataSerializerGetMapMetadataSerializedObjectPatcher` -- Adds `"MaxPlayers"` to the serialized object when saving a `MultiplayerMapMetadata`.
+- `MapMetadataSerializerDeserializePatcher` -- Reads `"MaxPlayers"` during deserialization and wraps the result in a `MultiplayerMapMetadata`.
+- `MapMetadataSaveEntryWriterCreateMapMetadataPatcher` -- On save, calls `ResetNumbering()` and wraps the metadata with the current max players count.
+
+### Thumbnail Rendering
+
+`StartingLocationThumbnailRenderingListenerPreThumnailRenderingPatcher` prevents starting locations from being hidden during thumbnail capture, so multiplayer map thumbnails show where each player starts.

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -1,0 +1,462 @@
+# Networking and IO Layer
+
+BeaverBuddies uses a custom networking stack split into two layers: **TimberNet**, a standalone networking library with no Timberborn dependencies, and the **IO bridge layer**, which connects TimberNet to the game's event replay system.
+
+## Architecture Overview
+
+```
++------------------+       +------------------+
+|  ServerEventIO   |       |  ClientEventIO   |    IO Bridge Layer
+|  (EventIO impl)  |       |  (EventIO impl)  |    (BeaverBuddies)
++--------+---------+       +--------+---------+
+         |                          |
++--------+---------+       +--------+---------+
+|   TimberServer   |       |   TimberClient   |    TimberNet Library
+|  (TimberNetBase) |       |  (TimberNetBase) |    (standalone)
++--------+---------+       +--------+---------+
+         |                          |
++--------+---------+       +--------+---------+
+| ISocketListener  |       |  ISocketStream   |    Transport Abstraction
+| (TCP / Steam /   |       |  (TCP / Steam)   |
+|  Multi)          |       |                  |
++------------------+       +------------------+
+```
+
+---
+
+## TimberNet Library
+
+TimberNet lives in its own project (`/TimberNet/`) and has zero dependencies on Timberborn or Unity. It depends only on `Newtonsoft.Json` and standard .NET libraries. This separation means it can be tested and developed independently of the game.
+
+**Key source files:**
+- `TimberNet/TimberNetBase.cs`
+- `TimberNet/TimberServer.cs`
+- `TimberNet/TimberClient.cs`
+
+---
+
+## Message Protocol
+
+All messages use a simple framing protocol:
+
+```
++-------------------+-------------------------------+
+| 4 bytes (length)  | N bytes (GZip-compressed JSON) |
++-------------------+-------------------------------+
+```
+
+1. **Length prefix** -- 4-byte big-endian integer indicating the size of the payload.
+2. **Payload** -- GZip-compressed JSON string (UTF-8 encoded before compression).
+
+Every JSON message contains at least two fields:
+- `ticksSinceLoad` -- the tick number this event belongs to
+- `type` -- the event type identifier
+
+### Constants and Limits
+
+| Constant | Value | Location |
+|---|---|---|
+| `HEADER_SIZE` | 4 bytes | `TimberNetBase` |
+| `MAX_BUFFER_SIZE` | 32,768 bytes (32 KB) | `TimberNetBase` |
+| TCP `MaxChunkSize` | 32,768 bytes (32 KB) | `TCPClientWrapper` |
+| TCP `MaxBytesPerSecond` | 1,048,576 (1 MB/s) | `TCPClientWrapper` |
+| Steam `MaxChunkSize` | 8,192 bytes (8 KB) | `SteamSocket` |
+| Steam `MaxBytesPerSecond` | 131,072 (128 KB/s) | `SteamSocket` |
+
+### Chunked Sending
+
+`SendDataWithLength()` splits large payloads into `MaxChunkSize` chunks, sleeping between them to respect `MaxBytesPerSecond`. The sleep duration is calculated as:
+
+```
+sleepMS = MaxChunkSize * 1000 / MaxBytesPerSecond
+```
+
+For TCP this is effectively zero (32 KB at 1 MB/s = ~31 ms). For Steam it is more significant (8 KB at 128 KB/s = ~62 ms), since Steam's P2P layer can only buffer 1 MB at a time.
+
+---
+
+## TimberNetBase
+
+`TimberNetBase` (`TimberNet/TimberNetBase.cs`) is the abstract base class shared by both server and client. It handles message framing, hash-based state verification, event queuing, and tick counting.
+
+### Message Framing
+
+- **`SendLength(ISocketStream, int)`** -- Writes a 4-byte big-endian length prefix to the stream.
+- **`SendDataWithLength(ISocketStream, byte[])`** -- Sends the length prefix followed by the data in chunks, respecting the stream's bandwidth limits.
+- **`MessageToBuffer(JObject)`** / **`MessageToBuffer(string)`** -- Serializes a message to a GZip-compressed byte array via `CompressionUtils.Compress()`.
+- **`BufferToStringMessage(byte[])`** -- Decompresses a byte array back to a JSON string via `CompressionUtils.Decompress()`.
+- **`TryReadLength(ISocketStream, out int)`** -- Reads the 4-byte big-endian length prefix from a stream.
+
+### Hash-Based State Verification
+
+The `Hash` property maintains a running hash of all events processed, used to detect desync between server and client.
+
+- **`Hash`** (property) -- Current hash value, initialized to `17`.
+- **`AddToHash(string)`** / **`AddToHash(byte[])`** -- Folds new data into the running hash using `CombineHash`.
+- **`CombineHash(int h1, int h2)`** -- `h1 * 31 + h2` (a standard multiplicative hash combiner).
+- **`AddEventToHash(JObject)`** -- For `SetState` events, resets the hash to the value in the message. For all other events, hashes the JSON string representation.
+- **`AddFileToHash(byte[])`** -- Hashes the raw map bytes (called when the client receives the map file).
+
+### Event Queue and Processing
+
+Events arrive on background threads and are queued for processing on the main thread:
+
+1. **`receivedEventQueue`** (`ConcurrentQueue<string>`) -- Thread-safe queue for raw JSON strings received from the network.
+2. **`receivedEvents`** (`List<JObject>`) -- Sorted list of parsed events waiting to be processed, ordered by tick.
+3. **`Update()`** -- Drains the concurrent queue into `receivedEvents` (via `ProcessReceivedEventsQueue`), processes pending maps, and fires log events.
+4. **`ReadEvents(int ticksSinceLoad)`** -- Sets the current `TickCount`, calls `Update()`, pops events for the current tick, calls `ProcessReceivedEvent` on each, then returns only game-relevant events (filtering out `SetState` and `Heartbeat`).
+5. **`InsertInScript(JObject, List<JObject>)`** -- Inserts a message into a sorted list by tick number.
+6. **`PopEventsForTick<T>(int, List<T>, Func<T, int>)`** -- Static helper that removes and returns all events from the front of a list whose tick is at or before the given tick.
+
+### Tick Tracking
+
+- **`TickCount`** (property) -- Current tick count, updated each time `ReadEvents` is called.
+- **`TicksBehind`** (property) -- How many ticks the last received event is ahead of the current tick. Returns 0 if no events are queued.
+- **`ShouldTick`** (virtual property) -- Returns `true` if `Started` is true. Overridden by `TimberClient` to also require events in the queue.
+
+### Listening Loop
+
+`StartListening(ISocketStream, bool isClient)` runs on a background thread and continuously reads messages:
+
+1. Reads the 4-byte length prefix.
+2. If this is the first message and we are a client, treats it as the map file (or an error message if length is 0).
+3. For subsequent messages, reads the full payload and enqueues the decompressed JSON string into `receivedEventQueue`.
+
+---
+
+## TimberServer
+
+`TimberServer` (`TimberNet/TimberServer.cs`) extends `TimberNetBase` to manage multiple connected clients.
+
+### Construction
+
+```csharp
+public TimberServer(
+    ISocketListener listener,
+    Func<Task<byte[]>> mapProvider,
+    Func<JObject>? initEventProvider
+)
+```
+
+- `listener` -- The socket listener (TCP, Steam, or Multi) that accepts incoming connections.
+- `mapProvider` -- Async function that provides the serialized map bytes to send to new clients.
+- `initEventProvider` -- Optional function that creates an initialization event (e.g., `InitializeClientEvent` with random seed state) sent to newly connecting clients.
+
+### Client Connection Flow
+
+When `Start()` is called, the server begins accepting clients in a background task loop:
+
+1. `listener.AcceptClient()` blocks until a client connects.
+2. If `IsAcceptingClients` is `false`, sends an error message and closes the connection.
+3. **`SendMap(client)`** -- Awaits the map bytes from `mapProvider`, calls `StartQueuing(client)` to begin buffering events for this client, then sends the map using `SendDataWithLength`.
+4. **`SendState(client)`** -- Sends a `SetState` event with tick 0 and the current `Hash` value, so the client starts with the correct hash. This is sent directly (not queued).
+5. If an `initEventProvider` is set, calls `DoUserInitiatedEvent(initEvent, sendNow: true)` to immediately send the init event to all clients.
+6. **`FinishQueuing(client)`** -- Flushes the queued messages to the client and removes it from the queuing map, so future events are sent directly.
+7. `StartListening(client, false)` -- Enters the infinite read loop for this client.
+
+### Event Handling
+
+- **`ReceiveEvent(JObject)`** -- Overrides the base to stamp the current `TickCount` onto incoming client messages before inserting them into the event queue. This ensures client events are assigned to the server's current tick.
+- **`DoUserInitiatedEvent(JObject)`** -- Adds the event to the hash (via base class) and sends it to all connected clients.
+- **`SendEventToClients(JObject, bool sendNow)`** -- Iterates over clients, removing disconnected ones. Uses a lock on `queuedMessages` to prevent races during client setup.
+- **`QueueOrSentToClient(ISocketStream, JObject)`** -- If the client is still in the queuing phase (map is being sent), buffers the message. Otherwise sends immediately.
+
+### Heartbeats
+
+**`SendHeartbeat()`** creates a `Heartbeat` event with the current tick and processes it as a user-initiated event. This ensures clients receive at least one event per tick so they know to advance.
+
+### Lifecycle
+
+- **`StopAcceptingClients(string errorMessage)`** -- Sets an error message that will be sent to any future connection attempts. Called after the first tick to prevent late joins (since Timberborn randomly initializes some state during load that is not serialized).
+- **`Close()`** -- Closes all client connections and stops the listener.
+
+---
+
+## TimberClient
+
+`TimberClient` (`TimberNet/TimberClient.cs`) extends `TimberNetBase` to connect to a server.
+
+### Key Behaviors
+
+- **`ShouldTick`** -- Returns `true` only if `Started` is true AND `receivedEvents.Count > 0`. This means the client will not advance the game until it has events from the server to process.
+- **`DoUserInitiatedEvent(JObject)`** -- Does NOT add the event to the local hash. Instead, it sends the event to the server and waits for the server to echo it back with an assigned tick. This ensures server-authoritative ordering.
+- **`ProcessReceivedEvent(JObject)`** -- Calls `AddEventToHash()` on the received event, keeping the client's hash in sync with the server's.
+
+### Connection
+
+`Start()` calls `client.ConnectAsync().Wait(3000)` with a 3-second timeout. If the connection times out, throws `ConnectionFailureException`. Then starts a background task running `StartListening(client, true)` to receive the map file and subsequent events.
+
+---
+
+## Transport Abstraction
+
+The networking layer uses two interfaces to abstract the underlying transport:
+
+### ISocketStream
+
+Defined in `TimberNet/ISocketStream.cs`:
+
+```csharp
+public interface ISocketStream
+{
+    bool Connected { get; }
+    string? Name { get; }
+    int MaxChunkSize { get; }
+    int MaxBytesPerSecond { get; }
+    int Read(byte[] buffer, int offset, int count);
+    void Write(byte[] buffer, int offset, int count);
+    void Close();
+    Task ConnectAsync();
+    byte[] ReadUntilComplete(int count);       // default implementation
+    void ReadUntilComplete(byte[] buffer, int count); // default implementation
+}
+```
+
+`ReadUntilComplete` is a default interface method that loops `Read()` calls until the requested number of bytes have been received, throwing `IOException` if the stream ends prematurely.
+
+### ISocketListener
+
+Defined in `TimberNet/ISocketListener.cs`:
+
+```csharp
+public interface ISocketListener
+{
+    void Start();
+    void Stop();
+    ISocketStream AcceptClient();  // blocking
+}
+```
+
+### TCP Transport
+
+**`TCPClientWrapper`** (`TimberNet/TCPClientWrapper.cs`) wraps a standard `TcpClient`:
+
+- `MaxChunkSize` = 32 KB, `MaxBytesPerSecond` = 1 MB/s
+- Two constructors: one with address/port for outbound connections, one with an existing `TcpClient` for server-accepted sockets.
+- `ConnectAsync()` delegates to `TcpClient.ConnectAsync()`.
+
+**`TCPListenerWrapper`** (`TimberNet/TCPListenerWrapper.cs`) wraps `TcpListener`:
+
+- Binds to `IPAddress.IPv6Any` with `IPv6Only = false`, enabling dual-stack (IPv4 and IPv6) on a single socket.
+- `AcceptClient()` blocks and returns a `TCPClientWrapper` wrapping the accepted `TcpClient`.
+
+### Steam Transport
+
+**`SteamSocket`** (`BeaverBuddies/Steam/SteamSocket.cs`) implements `ISocketStream` using Steamworks P2P networking:
+
+- `MaxChunkSize` = 8 KB, `MaxBytesPerSecond` = 128 KB/s (Steam can only buffer 1 MB at a time).
+- Uses `SteamNetworking.SendP2PPacket()` with `k_EP2PSendReliable` for writes.
+- Reads are backed by a `ConcurrentQueueWithWait<byte[]>` -- the `Read()` method blocks until data is available.
+- `ConnectAsync()` is a no-op (returns `Task.CompletedTask`) since the connection is already established when the user joins the Steam lobby.
+- Implements `ISteamPacketReceiver` to register with the `SteamPacketListener`.
+
+**`SteamListener`** (`BeaverBuddies/Steam/SteamListener.cs`) implements `ISocketListener` using Steam lobbies:
+
+- On `Start()`, creates a friends-only lobby via `SteamMatchmaking.CreateLobby()` with a capacity of 8.
+- Listens for `LobbyChatUpdate_t` callbacks. When a user joins, creates a `SteamSocket` for them and enqueues it.
+- `AcceptClient()` blocks on a `ConcurrentQueueWithWait<SteamSocket>` until a user joins the lobby.
+- `ShowInviteFriendsPanel()` opens the Steam overlay invite dialog.
+- Lobby visibility is controlled by `Settings.LobbyJoinable` (friends-only vs. invite-only).
+
+**`SteamPacketListener`** (`BeaverBuddies/Steam/SteamPacketListener.cs`) polls for incoming Steam packets on the main thread:
+
+- Maintains a `Dictionary<CSteamID, SteamSocket>` of registered sockets.
+- `Update()` calls `SteamNetworking.IsP2PPacketAvailable()` in a loop, reading each packet with `ReadP2PPacket()` and routing it to the correct `SteamSocket.ReceiveData()` by `CSteamID`.
+
+### MultiSocketListener
+
+`MultiSocketListener` (`TimberNet/MultiSocketListener.cs`) allows the server to accept connections from multiple transport types simultaneously:
+
+- Takes an array of `ISocketListener` instances (e.g., one TCP, one Steam).
+- On first `AcceptClient()` call, starts a background task per listener that continuously accepts clients and enqueues them into a shared `ConcurrentQueueWithWait<ISocketStream>`.
+- `AcceptClient()` blocks until any listener produces a connection.
+- `GetListener<T>()` retrieves a specific child listener by type.
+
+---
+
+## IO Bridge Layer
+
+The IO bridge layer connects TimberNet to BeaverBuddies' event replay system. It lives in `BeaverBuddies/IO/`.
+
+### EventIO Interface
+
+`EventIO` (`BeaverBuddies/IO/EventIO.cs`) is the central interface that `ReplayService` uses to read and write events:
+
+```csharp
+public interface EventIO
+{
+    void Update();
+    List<ReplayEvent> ReadEvents(int ticksSinceLoad);
+    void WriteEvents(params ReplayEvent[] events);
+    void Close();
+    bool RecordReplayedEvents { get; }
+    UserEventBehavior UserEventBehavior { get; }
+    bool IsOutOfEvents { get; }
+    int TicksBehind { get; }
+    bool ShouldSendHeartbeat { get; }
+    bool HasEventsForTick(int tick);
+}
+```
+
+#### UserEventBehavior Enum
+
+Controls what happens when a user-initiated event is recorded:
+
+| Value | Meaning | Used by |
+|---|---|---|
+| `Play` | Execute the event immediately on the local game | `FileWriteIO` |
+| `Send` | Send the event to the server; do not execute locally | `ClientEventIO` |
+| `QueuePlay` | Queue the event to be played on the next tick (ensures ordering) | `ServerEventIO` |
+
+#### Static Singleton Pattern
+
+`EventIO` uses a static `instance` field with `Get()`, `Set(EventIO)`, and `Reset()` methods. This allows global access from Harmony patches and other static contexts. `Reset()` calls `Close()` on the current instance before clearing it.
+
+#### Static Helper Properties
+
+- **`ShouldPauseTicking`** -- Returns `true` if the current IO reports `IsOutOfEvents` (used to pause the game when waiting for network data).
+- **`ShouldPlayPatchedEvents`** -- Returns `true` if events from Harmony patches should be executed. Always true during replay; otherwise depends on `UserEventBehavior == Play`.
+- **`SkipRecording`** -- Returns `true` if currently replaying events and the IO says not to record them (prevents the client from re-sending events it received from the server).
+
+### NetIOBase\<T\>
+
+`NetIOBase<T>` (`BeaverBuddies/IO/NetIOBase.cs`) is the abstract base bridging `TimberNetBase` to `EventIO`:
+
+- Generic over `T : TimberNetBase` (either `TimberServer` or `TimberClient`).
+- **`ReadEvents(int)`** -- Delegates to `NetBase.ReadEvents()`, then deserializes each `JObject` into a `ReplayEvent` using `JsonSettings.Deserialize<ReplayEvent>()`.
+- **`WriteEvents(ReplayEvent[])`** -- Serializes each `ReplayEvent` to JSON, parses it into a `JObject`, and calls `NetBase.DoUserInitiatedEvent()`.
+- **`IsOutOfEvents`** -- Delegates to `!NetBase.ShouldTick`.
+- **`TicksBehind`** -- Delegates to `NetBase.TicksBehind`.
+- Manages an optional `SteamPacketListener` via `TryRegisterSteamPacketReceiver()`.
+
+### ServerEventIO
+
+`ServerEventIO` (`BeaverBuddies/IO/ServerEventIO.cs`) extends `NetIOBase<TimberServer>`:
+
+| Property | Value | Reason |
+|---|---|---|
+| `RecordReplayedEvents` | `true` | Server records and sends all events to clients |
+| `ShouldSendHeartbeat` | `true` | Clients need heartbeats to know when to advance |
+| `UserEventBehavior` | `QueuePlay` | Events are queued until the next tick boundary for deterministic ordering |
+
+**`Start(byte[] mapBytes)`** sets up the server:
+
+1. Creates a `TCPListenerWrapper` on the configured port.
+2. If Steam is enabled, also creates a `SteamListener`.
+3. Wraps them in a `MultiSocketListener`.
+4. Registers any `ISteamPacketReceiver` listeners with a `SteamPacketListener`.
+5. Creates a `TimberServer` with a map provider that returns the static `mapBytes` and an init event provider that creates an `InitializeClientEvent`.
+
+**`StopAcceptingClients()`** is called after the first tick to prevent late joins, displaying a user-friendly error message to anyone who tries to connect.
+
+### ClientEventIO
+
+`ClientEventIO` (`BeaverBuddies/IO/ClientEventIO.cs`) extends `NetIOBase<TimberClient>`:
+
+| Property | Value | Reason |
+|---|---|---|
+| `RecordReplayedEvents` | `false` | Client should not re-send events received from server |
+| `ShouldSendHeartbeat` | `false` | Only the server sends heartbeats |
+| `UserEventBehavior` | `Send` | Client sends events to the server for validation |
+
+Created via the static factory `ClientEventIO.Create(ISocketStream, MapReceived, Action<string>)`:
+
+1. Registers the socket with a `SteamPacketListener` if applicable.
+2. Creates a `TimberClient` and wires up `OnMapReceived`, `OnLog`, and `OnError` callbacks.
+3. Calls `NetBase.Start()` to connect.
+4. Returns `null` if the connection fails.
+
+---
+
+## File IO
+
+For replay recording and debugging, BeaverBuddies provides file-based `EventIO` implementations in `BeaverBuddies/IO/FileIO.cs`.
+
+### FileWriteIO
+
+Records all events to a JSON file as they happen:
+
+- `UserEventBehavior = Play` -- events execute normally.
+- `RecordReplayedEvents = true` -- captures everything.
+- `WriteEvents()` serializes each event to JSON and appends it to the file.
+- The file format is a JSON array (`[` on open, each event followed by `,`, `]` on close).
+- Uses a `ReaderWriterLock` for thread safety.
+
+### FileReadIO
+
+Plays back events from a previously recorded JSON file:
+
+- Reads the entire file on construction, parsing it into a `List<ReplayEvent>`.
+- `ReadEvents(int)` uses `TimberNetBase.PopEventsForTick()` to return events up to the requested tick.
+- `IsOutOfEvents` returns `true` when the event list is empty (replay is finished).
+- `RecordReplayedEvents = false` -- does not re-record during playback.
+
+### RecordToFileService
+
+An `IPostLoadableSingleton` that automatically sets up `FileWriteIO` on game load, saving replays to `Replays/<SaveName>.json`.
+
+---
+
+## CompressionUtils
+
+`CompressionUtils` (`TimberNet/CompressionUtils.cs`) provides static GZip compression and decompression:
+
+```csharp
+public static byte[] Compress(string text)    // UTF-8 encode, then GZip at Optimal level
+public static string Decompress(byte[] data)  // GZip decompress, then UTF-8 decode
+```
+
+Used by `MessageToBuffer` and `BufferToStringMessage` in `TimberNetBase`.
+
+---
+
+## ConcurrentQueueWithWait
+
+`ConcurrentQueueWithWait<T>` (`TimberNet/ConcurrentQueueWithWait.cs`) wraps `ConcurrentQueue<T>` with a `ManualResetEvent` for blocking waits:
+
+- **`Enqueue(T)`** -- Adds an item and signals the event.
+- **`WaitAndTryDequeue(out T)`** -- Blocks until an item is available, then dequeues it. Resets the event if the queue is empty after dequeue.
+- **`Wait()`** -- Blocks until the event is signaled.
+
+Used by `SteamSocket` (for read buffering), `SteamListener` (for queuing joining users), and `MultiSocketListener` (for aggregating accepted connections).
+
+---
+
+## Data Flow Summary
+
+### Server sending an event
+
+```
+ReplayService.RecordEvent()
+  -> eventsToPlay queue (QueuePlay behavior)
+  -> ReplayService.DoTickIO()
+    -> ReplayEvents() dequeues, replays, records s0
+    -> SendEvents() groups into GroupedEvent
+      -> EventIO.WriteEvents()
+        -> NetIOBase.WriteEvents()
+          -> TimberServer.DoUserInitiatedEvent()
+            -> AddEventToHash()
+            -> SendEventToClients()
+              -> SendEvent() per client
+                -> MessageToBuffer() (JSON -> GZip)
+                -> SendDataWithLength() (chunked)
+```
+
+### Client receiving and processing an event
+
+```
+Background thread: StartListening()
+  -> ReadUntilComplete() reads length + payload
+  -> BufferToStringMessage() (GZip -> JSON)
+  -> receivedEventQueue.Enqueue()
+
+Main thread: EventIO.ReadEvents()
+  -> NetIOBase.ReadEvents()
+    -> TimberClient.ReadEvents()
+      -> Update() drains queue into receivedEvents
+      -> PopEventsToProcess() for current tick
+      -> ProcessReceivedEvent() -> AddEventToHash()
+      -> Filter out SetState/Heartbeat
+    -> Deserialize JObject to ReplayEvent
+  -> ReplayService.ReplayEvents() executes each event
+```

--- a/docs/port-forwarding.md
+++ b/docs/port-forwarding.md
@@ -1,0 +1,89 @@
+# Port Forwarding Guide
+
+This guide walks you through setting up port forwarding for BeaverBuddies direct TCP connections. BeaverBuddies uses port **25565** by default (the same as Minecraft, so Minecraft port forwarding guides also apply).
+
+You can also search for port forwarding guides specific to your router model.
+
+## Step 1: Find Your Local IP Address
+
+### Windows
+
+1. Press the **Windows key**, type `cmd`, and press **Enter**
+2. In the Command Prompt, type `ipconfig` and press **Enter**
+3. Look for **IPv4 Address** under your active network connection
+4. Write down that address (e.g., `192.168.1.105`) - this is your local IP
+
+### macOS
+
+1. Open **System Settings** > **Network**
+2. Select your active connection (Wi-Fi or Ethernet)
+3. Your IP address is displayed (e.g., `192.168.1.105`)
+
+Alternatively, open Terminal and run:
+
+```bash
+ipconfig getifaddr en0
+```
+
+## Step 2: Access Your Router Settings
+
+1. Open a web browser
+2. Type your router's IP address in the address bar. Common addresses:
+   - `192.168.0.1`
+   - `192.168.1.1`
+   - `10.0.0.1`
+3. Press **Enter**
+4. Log in with your router's username and password
+   - Check the back/bottom of your router for default credentials
+   - If you can't find them, search for your router model + "default login"
+
+## Step 3: Find the Port Forwarding Section
+
+Look for a section called **Port Forwarding**, **Virtual Server**, or **NAT**. It may be under:
+- Advanced Settings
+- Security
+- Network Settings
+- Firewall
+
+> Every router interface is different. If you can't find it, search your router name + "port forwarding" online.
+
+## Step 4: Create a Port Forwarding Rule
+
+1. Click **Add**, **Create**, or **New**
+2. Fill in the following:
+
+| Field | Value |
+|-------|-------|
+| Name / Description | `Timberborn` (or any name you like) |
+| Local IP / Internal IP | Your local IP from Step 1 |
+| Internal Port | `25565` |
+| External Port | `25565` |
+| Protocol | **TCP** (if you can only choose one) or **TCP and UDP** |
+
+3. If the form asks for a start and end port (or "translation" ports), enter `25565` for all of them
+4. Save the rule
+
+> If your router only lets you create one protocol at a time, create a rule for **TCP** first, then create a second rule for **UDP** with the same settings.
+
+## Step 5: Verify
+
+1. Start hosting a game in BeaverBuddies
+2. Visit [yougetsignal.com/tools/open-ports](https://www.yougetsignal.com/tools/open-ports/)
+3. Enter port `25565` and click **Check**
+4. If it shows as **Open**, you're good to go
+
+## Sharing Your IP Address
+
+The host needs to share their **public** (external) IP address with the client. Find it at:
+- [icanhazip.com](https://icanhazip.com/)
+- [whatismyip.com](https://www.whatismyip.com/)
+
+> Your public IP may change periodically. Check it each time you host.
+
+## Alternatives to Port Forwarding
+
+If you can't set up port forwarding:
+
+- **Steam P2P**: Use Steam's peer-to-peer networking instead (see [User Guide](user-guide#option-1-steam-peer-to-peer-easiest))
+- **Hamachi**: [vpn.net](https://vpn.net/) can simulate LAN play for free for small groups
+- **Tailscale / ZeroTier**: Modern VPN alternatives that are often easier to set up than traditional port forwarding

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,292 @@
+# Testing and Debugging
+
+This page covers the testing tools, debugging workflows, and logging infrastructure available in BeaverBuddies.
+
+## ClientServerSimulator
+
+**File:** `ClientServerSimulator/Drivers.cs`
+
+The `ClientServerSimulator` project is a standalone Windows Forms application for testing the networking layer without running Timberborn. It simulates a server and client communicating over localhost.
+
+### DriverBase\<T\>
+
+The abstract `DriverBase<T>` class provides the foundation for both server and client test drivers:
+
+```csharp
+internal abstract class DriverBase<T> where T : TimberNetBase
+{
+    public const string LOCALHOST = "127.0.0.1";
+    public const int PORT = 25565;
+
+    protected List<JObject> scriptedEvents;
+    public readonly T netBase;
+    protected int ticks = 0;
+
+    public DriverBase(string scriptPath, T netBase) { ... }
+}
+```
+
+**Key methods:**
+
+- **Constructor** -- Takes a path to a JSON script file and a `TimberNetBase` instance. Reads the script file with `ReadScriptFile()`, which parses a JSON array of event objects.
+- **`TryTick()`** -- If `netBase.ShouldTick` is true, increments the tick counter and reads events from the network.
+- **`Update()`** -- Reads network events, then iterates through scripted events. Uses `TimberNetBase.PopEventsForTick()` to find events scheduled for the current tick and feeds them to `netBase.DoUserInitiatedEvent()`.
+- **`ProcessEvent(JObject)`** -- Virtual method for handling received events. The base implementation handles `SpeedSetEvent` by raising the `OnTargetSpeedChanged` event.
+
+### ClientDriver
+
+```csharp
+internal class ClientDriver : DriverBase<TimberClient>
+{
+    const string SCRIPT_PATH = "client.json";
+
+    public ClientDriver() : base(SCRIPT_PATH,
+        new TimberClient(new TCPClientWrapper(LOCALHOST, PORT))) { }
+}
+```
+
+Reads scripted client events from `client.json` and connects to localhost on port 25565.
+
+### ServerDriver
+
+```csharp
+internal class ServerDriver : DriverBase<TimberServer>
+{
+    const string SCRIPT_PATH = "server.json";
+    const string SAVE_PATH = "save.timber";
+
+    public ServerDriver() : base(SCRIPT_PATH,
+        new TimberServer(new TCPListenerWrapper(PORT),
+            () => File.ReadAllBytesAsync(SAVE_PATH),
+            CreateInitEvent())) { }
+}
+```
+
+- Reads the save file from `save.timber` to provide map bytes to connecting clients.
+- Creates a `RandomStateSetEvent` as the init event with a fixed seed (`1234`) for deterministic testing.
+- Overrides `ProcessEvent` to also call `DoUserInitiatedEvent` on the server (simulating the server replaying its own events).
+- Overrides `Update` to wait for at least one client before processing scripted events.
+
+### Writing Test Scripts
+
+Test scripts are JSON arrays where each element is an event object with a `ticksSinceLoad` field indicating when it should fire:
+
+```json
+[
+  { "$type": "BeaverBuddies.Events.SpeedSetEvent", "ticksSinceLoad": 0, "speed": 1 },
+  { "$type": "BeaverBuddies.Events.PlaceBuildingEvent", "ticksSinceLoad": 10, ... }
+]
+```
+
+## Inspector Project
+
+**Directory:** `Inspector/`
+
+The `Inspector` project is a console application containing utilities and tests.
+
+### UpdateLocalizations
+
+**File:** `Inspector/UpdateLocalizations.cs`
+
+A utility for batch-updating localization CSV files. It:
+
+1. Reads structured translation input from `input.txt` (formatted as markdown with locale headers and CSV code blocks).
+2. Parses blocks matching the pattern `### ... (deDE) \`\`\`csv ... \`\`\``.
+3. For each locale, finds the matching CSV file in `BeaverBuddies/Localizations/`.
+4. Adds new keys that are not already present, skipping duplicates.
+5. Reports a summary of added keys, missing CSV files, and unmatched locales.
+
+### Unit Tests
+
+The Inspector project also contains unit tests for networking components:
+
+- **`ConcurrentQueueWithWaitTests.cs`** -- Tests for the thread-safe queue used in Steam networking.
+- **`HasSetTest.cs`** -- Tests validating HashSet enumeration order determinism (relevant to the desync investigation documented in `DeterminismService.cs`).
+
+## Replay File Debugging
+
+**File:** `BeaverBuddies/IO/FileIO.cs`
+
+BeaverBuddies includes a file-based event recording and playback system for reproducing bugs offline.
+
+### FileWriteIO
+
+`FileWriteIO` implements the `EventIO` interface and writes all events to a JSON file as they occur:
+
+```csharp
+public class FileWriteIO : EventIO
+{
+    public bool RecordReplayedEvents => true;
+    public UserEventBehavior UserEventBehavior => UserEventBehavior.Play;
+
+    public void WriteEvents(params ReplayEvent[] events)
+    {
+        for (int i = 0; i < events.Length; i++)
+        {
+            string json = JsonConvert.SerializeObject(e, settings);
+            WriteToFile(json + ",");
+        }
+    }
+}
+```
+
+The output file is a JSON array written incrementally (opened with `[`, each event appended with a trailing comma, closed with `]`). Thread safety is maintained via a `ReaderWriterLock`.
+
+`RecordToFileService` is an `IPostLoadableSingleton` that automatically sets up `FileWriteIO` when enabled. The file is saved to `Replays/<saveName>.json`.
+
+### FileReadIO
+
+`FileReadIO` reads a previously recorded JSON file and replays events at the correct ticks:
+
+```csharp
+public List<ReplayEvent> ReadEvents(int ticksSinceLoad)
+{
+    return TimberNetBase.PopEventsForTick(ticksSinceLoad, events, e => e.ticksSinceLoad);
+}
+```
+
+It loads the entire file at construction time and uses `PopEventsForTick` to return events matching the current tick. `IsOutOfEvents` returns true when all events have been consumed.
+
+### Usage
+
+To record a session:
+1. Enable `RecordToFileService` (or set up `FileWriteIO` manually).
+2. Play through the scenario you want to capture.
+3. The JSON file is written to the `Replays/` directory.
+
+To replay a session:
+1. Create a `FileReadIO` pointing to the recorded JSON file.
+2. Set it as the active `EventIO` via `EventIO.Set()`.
+3. Load the same save file. Events replay automatically at the correct ticks.
+
+This is particularly useful for reproducing desyncs -- record the server's events, then replay them on a client to see where divergence occurs.
+
+## Desync Debugging Workflow
+
+When a desync occurs, follow this workflow to identify the root cause.
+
+### Step 1: Enable Tracing
+
+Set `Settings.AlwaysTrace` to `true` in the mod settings, or use the one-time flag:
+
+```csharp
+Settings.TemporarilyDebug = true;
+```
+
+`TemporarilyDebug` enables debug mode for the current session without persisting the setting. It is useful when you want to reproduce a specific desync once.
+
+When `Settings.Debug` is true:
+
+- `DesyncDetecterService` records per-tick traces on both server and client.
+- Traces are exchanged via `TraceLoggedForTickEvent` events.
+- The RNG state (`s0`) is logged at each random call during ticks.
+- Additional trace points fire in natural resource reproduction, pathfinding, water simulation, and entity bucket management.
+
+### Step 2: Reproduce the Desync
+
+Play the game until the desync occurs. With tracing enabled, both sides record detailed logs of what happened each tick.
+
+### Step 3: Compare Traces
+
+When a desync is detected, `DesyncDetecterService.VerifyTraces()` automatically generates a detailed comparison log:
+
+```
+Desync detected for tick 42!
+========== Trace history ==========
+(shared history from previous ticks)
+========== Shared History for Desynced Tick 42 ==========
+Tick 42 started
+Marking spots for Tree at (5, 0, 3) (guid-1234)
+Spots updated: 0 --> 2
+========== Desynced Trace ==========
+---------- My Trace ----------
+Spawning: Tree, (6, 0, 4)
+---------- Other Trace ----------
+Spawning: Tree, (7, 0, 5)
+========== Desynced Log End ==========
+```
+
+The log shows:
+- **Shared history** -- What both sides agreed on before divergence.
+- **Desynced trace** -- The first point where the traces differ, with stack traces for the last few entries.
+
+### Step 4: Identify the Divergence
+
+Common patterns to look for:
+
+- **RNG state mismatch before a specific trace** -- Something consumed random numbers non-deterministically between two trace points.
+- **Missing or extra trace entries** -- A system executed on one side but not the other.
+- **Different values in hash traces** -- Water or moisture maps diverged, indicating a parallel tick ordering issue.
+
+### Step 5: Add More Trace Points
+
+If the existing traces are insufficient, add new `DesyncDetecterService.Trace()` calls in the suspected area. Always guard with `if (!Settings.Debug) return;` to avoid performance overhead in normal play:
+
+```csharp
+if (!Settings.Debug) return;
+DesyncDetecterService.Trace($"MySystem processing {entityId} at {coordinates}");
+```
+
+## ReportingService
+
+**File:** `BeaverBuddies/Reporting/ReportingService.cs`
+
+`ReportingService` handles automated desync report submission to an Airtable database, subject to user consent (`Settings.ReportingConsent`).
+
+### PostDesync
+
+The main method `PostDesync()` submits:
+
+| Field | Content |
+|---|---|
+| `SaveID` | Hash of the map name |
+| `EventID` | Hash of the desync trace (from `DesyncDetecterService.GetLastDesyncID()`) |
+| `Role` | "Server" or "Client" |
+| `IsCrash` | Always `false` for desyncs |
+| `DesyncTrace` | The desync trace text (compressed if too large) |
+| `Logs` | The Unity console log (read from `Application.consoleLogPath`) |
+| `VersionInfo` | Mod and game version information |
+
+If the trace exceeds Airtable's 100,000 character limit, it is compressed to Base64 first. If still too large, it is truncated.
+
+Map save data can optionally be uploaded as a zip attachment to the created record.
+
+### Authentication
+
+The Airtable access token is embedded as a resource (`pat.properties`) at build time. If the file is not present, reporting is silently disabled.
+
+## Logging
+
+**File:** `BeaverBuddies/Plugin.cs`
+
+BeaverBuddies uses BepInEx's logging infrastructure through the `Plugin` class:
+
+### Log Methods
+
+```csharp
+public static void Log(string message)       // Info level, respects SilenceLogging
+public static void LogWarning(string message) // Warning level, always logged
+public static void LogError(string message)   // Error level, always logged
+public static void LogStackTrace()            // Dumps current stack trace at info level
+```
+
+All messages are prefixed with a timestamp (`[HH-mm-ss.ff]`).
+
+`Plugin.Log()` respects `Settings.VerboseLogging` -- when `SilenceLogging` is true, info-level messages are suppressed. Warnings and errors are always logged regardless of this setting.
+
+### BepInEx Console
+
+BepInEx provides a console window (on Windows) or log file that captures all output. The log file path is available via `UnityEngine.Application.consoleLogPath` and is used by `ReportingService` when submitting desync reports.
+
+### Conditional Logging in Debug Mode
+
+Many trace and diagnostic messages are guarded by `Settings.Debug`:
+
+```csharp
+if (Settings.Debug)
+{
+    DesyncDetecterService.Trace($"Tick RNG; s0 before: {UnityEngine.Random.state.s0:X8}");
+}
+```
+
+This two-tier approach (warning messages always visible, detailed traces only in debug mode) keeps normal gameplay performant while providing deep diagnostics when needed.

--- a/docs/tick-synchronization.md
+++ b/docs/tick-synchronization.md
@@ -1,0 +1,376 @@
+# Tick Synchronization
+
+BeaverBuddies must ensure that the server and all clients produce identical game state on every tick. This page documents how the tick synchronization system works, from the central `ReplayService` orchestrator down to the low-level tick loop patching in `TickingService`.
+
+## The Synchronization Problem
+
+Timberborn uses a **bucket-based tick system**. Rather than updating all entities once per frame, the game divides entities into buckets and updates a variable number of buckets per frame depending on game speed and frame rate. A single "tick" consists of updating all buckets (plus singleton tick services) exactly once.
+
+For multiplayer to work, both server and client must:
+
+1. Execute the same set of events at the same tick boundaries.
+2. Maintain identical random number generator state.
+3. Process entities in the same order.
+
+The core challenge is that user actions (placing buildings, changing settings, etc.) can happen at any point during a frame, but they must be applied at deterministic tick boundaries. The `ReplayService` solves this by capturing events, deferring them to tick boundaries, and replaying them in a consistent order on all peers.
+
+---
+
+## ReplayService
+
+`ReplayService` (`BeaverBuddies/ReplayService.cs`) is the central orchestrator for multiplayer synchronization. It implements `IReplayContext`, `IPostLoadableSingleton`, `IUpdatableSingleton`, and `IResettableSingleton`.
+
+### Key Fields
+
+| Field | Type | Purpose |
+|---|---|---|
+| `ticksSinceLoad` | `int` | Monotonically increasing tick counter, set via a property that also updates `TimeTimePatcher` and `DesyncDetecterService` |
+| `IsReplayingEvents` | `static bool` | True while events are being replayed; prevents re-recording events during replay |
+| `IsDesynced` | `bool` | Set to true when a desync is detected; disables further synchronization |
+| `eventsToSend` | `ConcurrentQueue<ReplayEvent>` | Events waiting to be sent to connected peers |
+| `eventsToPlay` | `ConcurrentQueue<ReplayEvent>` | Events queued locally for deferred execution (server's `QueuePlay` behavior) |
+| `TargetSpeed` | `float` | The user's desired game speed, distinct from the actual speed which may be adjusted for catch-up |
+| `io` | `EventIO` | Reference to the current IO implementation (server, client, or file) via `EventIO.Get()` |
+| `IsLoaded` | `static bool` | Whether the service has finished initialization |
+
+### Initialization
+
+After the game scene loads, `ReplayService` waits 2 update frames (`waitUpdates`) before calling `Initialize()`. This delay ensures Timberborn's own random initialization (tree lifespans, etc.) has completed. `Initialize()` sets `IsLoaded = true` and starts the desync detection system.
+
+### DoTick()
+
+Called at the very start of each tick (before any entity updates), via `TickingService`:
+
+```csharp
+public void DoTick()
+{
+    // 1. If server in debug mode, capture desync traces from prior tick
+    // 2. Increment ticksSinceLoad
+    // 3. If server, enqueue a HeartbeatEvent
+    // 4. Call DoTickIO() to replay and send events
+    // 5. Update speed (pause if out of events, speed up if behind)
+    // 6. After tick 1, stop accepting new clients (server only)
+}
+```
+
+The tick counter is incremented before `DoTickIO()`, so events are processed at the new tick number.
+
+### DoTickIO()
+
+The main synchronization method, called from both `DoTick()` and `UpdateSingleton()` (when paused):
+
+```csharp
+private void DoTickIO()
+{
+    ReplayEvents();
+    SendEvents();
+}
+```
+
+### ReplayEvents()
+
+Reads and executes pending events for the current tick:
+
+```
+1. Read events from IO for current tick
+   -> io.ReadEvents(TicksSinceLoad)
+   -> Flattens any GroupedEvent into individual events
+
+2. Dequeue locally queued events (eventsToPlay)
+   -> Sets their ticksSinceLoad to current tick
+   -> Appends to the replay list
+
+3. Set IsReplayingEvents = true
+
+4. For each event:
+   a. Check RNG state (randomS0Before) if not in Debug mode
+      -> If mismatch, call HandleDesync() and stop
+   b. Record current random state (s0) on the event
+   c. Call event.Replay(this)
+   d. If recording is not skipped, enqueue for sending
+
+5. Set IsReplayingEvents = false
+```
+
+The RNG state check is the primary desync detection mechanism. Each event records `randomS0Before` -- the Unity random state just before the event was first played on the server. When the client replays the same event, it verifies its own random state matches. A mismatch means the game states have diverged.
+
+### SendEvents()
+
+Groups all pending events and sends them to connected peers:
+
+```csharp
+private void SendEvents()
+{
+    // Drain eventsToSend queue into a list
+    // Stamp each event with ticksSinceLoad
+    // Wrap in a GroupedEvent
+    // Call EventIO.Get().WriteEvents(group)
+}
+```
+
+Events are grouped into a single `GroupedEvent` per tick to ensure all events for a tick arrive together. This prevents a client from seeing a partial tick's events and starting to process them prematurely.
+
+### RecordEvent()
+
+Called by Harmony patches when the user performs an action:
+
+```csharp
+public void RecordEvent(ReplayEvent replayEvent)
+{
+    // Skip if currently replaying (would cause re-recording)
+    // Skip if not loaded yet
+
+    switch (io.UserEventBehavior):
+        QueuePlay -> eventsToPlay.Enqueue(replayEvent)
+        Send      -> eventsToSend.Enqueue(replayEvent)
+}
+```
+
+- **Server (QueuePlay):** The event goes into `eventsToPlay` and will be replayed at the next tick boundary via `ReplayEvents()`. This ensures the event executes at the same tick on server and clients.
+- **Client (Send):** The event goes into `eventsToSend` and is transmitted to the server without local execution. The server will assign a tick and echo it back.
+
+### Speed Management
+
+`ReplayService` manages game speed to keep clients synchronized:
+
+```csharp
+private void UpdateSpeed()
+{
+    // If out of events: pause (speed = 0)
+    // If behind by more ticks than target speed:
+    //   speed up to min(ticksBehind, 10)
+    // Otherwise: set speed to TargetSpeed
+}
+```
+
+- `TargetSpeed` is the user's requested speed (set via `SetTargetSpeed()`).
+- If the client falls behind (more received events than processed), the game speeds up to catch up, capped at speed 10.
+- If the client runs out of events (server hasn't sent heartbeats for future ticks yet), the game pauses.
+- Speed changes use `SpeedChangePatcher.SetSpeedSilentlyNow()` to avoid triggering the speed-change event patches.
+
+### Desync Handling
+
+When `HandleDesync()` is called:
+
+1. Sets `IsDesynced = true` to stop further sync attempts.
+2. Creates a `ClientDesyncedEvent` with debug information.
+3. Sends it to the server immediately.
+4. Pauses the game.
+5. Resets the `EventIO` (disconnects).
+
+### GroupedEvent
+
+```csharp
+class GroupedEvent : ReplayEvent
+{
+    public List<ReplayEvent> events;
+}
+```
+
+A container event that wraps multiple events for a single tick. When received, `ReadEventsFromIO()` flattens grouped events back into individual events before replay. `GroupedEvent.Replay()` throws `NotImplementedException` -- it must never be replayed directly.
+
+### HeartbeatEvent
+
+```csharp
+class HeartbeatEvent : ReplayEvent
+{
+    public override void Replay(IReplayContext context) { }  // no-op
+}
+```
+
+A no-op event sent by the server each tick. Its purpose is to signal clients that a tick has occurred, even if no player actions happened. Without heartbeats, clients would have no events for that tick and would pause indefinitely.
+
+---
+
+## TickingService
+
+`TickingService` (`BeaverBuddies/ReplayService.cs`, same file) controls how the game's tick loop operates during multiplayer. It replaces Timberborn's default `TickableBucketService.TickBuckets` method via a Harmony prefix patch.
+
+### The Patching Mechanism
+
+```
+[HarmonyPatch(typeof(TickableBucketService), nameof(TickableBucketService.TickBuckets))]
+static class TickableBucketServiceTickUpdatePatcher
+{
+    static bool Prefix(TickableBucketService __instance, int numberOfBucketsToTick)
+    {
+        if (EventIO.IsNull) return true;  // no multiplayer, use default
+        TickingService ts = GetSingleton<TickingService>();
+        if (ts == null) return true;
+        return ts.TickBuckets(__instance, numberOfBucketsToTick);
+    }
+}
+```
+
+When multiplayer is active, the patch returns `false` from the prefix, completely replacing the original method with `TickingService.TickBuckets()`.
+
+### TickBuckets -- The Core Loop
+
+The replacement tick loop:
+
+```
+while (ShouldTick(__instance, numberOfBucketsToTick--)):
+    if (TickReplayServiceOrNextBucket(__instance)):
+        numberOfBucketsToTick++  // refund the bucket if we ticked ReplayService
+OnTickingCompleted()
+```
+
+### ShouldTick Decision Logic
+
+`ShouldTick()` determines whether to continue processing buckets:
+
+```
+1. If ShouldInterruptTicking is set -> stop
+2. If TargetSpeed == 0 (user paused) -> stop
+3. If at start of tick AND ReplayService not ready -> stop
+   (client waiting for server heartbeat)
+4. If ShouldCompleteFullTick is set -> continue until bucket index wraps to 0
+5. Otherwise -> continue while numberOfBucketsToTick > 0
+```
+
+### TickReplayServiceOrNextBucket
+
+This method injects `ReplayService.DoTick()` at the start of each tick cycle:
+
+```
+if at start of tick (bucket index == 0):
+    if haven't ticked ReplayService yet:
+        Finish any parallel tick operations
+        Call replayService.DoTick()
+        Set HasTickedReplayService = true
+        Return true (refund bucket)
+    else:
+        Reset HasTickedReplayService = false
+
+Tick the next bucket normally
+Update NextBucket
+Return false
+```
+
+This ensures that:
+- `ReplayService.DoTick()` runs exactly once per tick cycle, before any entity buckets.
+- Parallel tick operations from the previous tick are completed before the replay service runs.
+- The replay service tick does not consume one of the allocated bucket slots.
+
+### Key Properties
+
+| Property | Type | Purpose |
+|---|---|---|
+| `ShouldInterruptTicking` | `bool` | When true, stops ticking ASAP (resets each frame via `OnTickingCompleted`) |
+| `ShouldCompleteFullTick` | `bool` | When true, forces ticking to continue until the tick cycle completes |
+| `HasTickedReplayService` | `bool` | Tracks whether `DoTick()` has been called this tick cycle |
+| `NextBucket` | `int` | The current bucket index, exposed for other services |
+
+### FinishFullTickAndThen
+
+```csharp
+public void FinishFullTickAndThen(Action value)
+{
+    onCompletedFullTick.Add(value);
+    ShouldCompleteFullTick = true;
+}
+```
+
+Schedules a callback to run after the current tick completes. Used by `ReplayService.FinishFullTickIfNeededAndThen()` to ensure actions that need a consistent game state (like saving) happen at tick boundaries.
+
+### IEarlyTickableSingleton
+
+```csharp
+public interface IEarlyTickableSingleton : ITickableSingleton { }
+```
+
+A marker interface. The `TickableSingletonServicePatcher` Harmony patch reorders the singleton tick list so that any `IEarlyTickableSingleton` implementations are ticked first, before other tickable singletons. This ensures certain services run at the very beginning of each tick's singleton phase.
+
+---
+
+## Supporting Services
+
+### TickProgressService
+
+`TickProgressService` (`BeaverBuddies/TickProgressService.cs`) provides information about how far through a tick the game currently is. This is useful for smooth visual interpolation between discrete tick updates.
+
+**Key methods:**
+
+- **`HasTicked(EntityComponent)`** -- Returns whether a given entity has already been updated in the current partial tick. Uses the entity's bucket index compared to the current bucket index. Handles the edge case where `_nextBucketIndex == 0` (either just ticked the replay service or about to).
+- **`PercentTicked(EntityComponent)`** -- Returns a `float` (0.0 to 1.0) representing how many buckets have ticked since this entity's bucket. Used for animation interpolation.
+- **`TimeAtLastTick(EntityComponent)`** -- Returns `Time.time` if the entity has ticked this frame, or `Time.time - Time.fixedDeltaTime` if not. Useful for time-based interpolation.
+- **`GetEntityBucketIndex(EntityComponent)`** -- Looks up which bucket an entity belongs to via `TickableBucketService.GetEntityBucketIndex()`.
+
+### TickReplacerService
+
+`TickReplacerService` (`BeaverBuddies/TickReplacerService.cs`) moves certain frame-based updates to tick-based updates for determinism.
+
+Some Timberborn systems perform work in `UpdateSingleton()` (called every frame) that has gameplay effects. Since frame rate varies between machines, these updates must be moved to `Tick()` for deterministic multiplayer. Currently handles:
+
+- **`RecoveredGoodStackSpawner`** -- Normally spawns recovered goods during its `UpdateSingleton`. The original update is suppressed by a Harmony patch (`RecoveredGoodStackSpawnerUpdateSingletonPatcher`), and `TickReplacerService.Tick()` calls the base update behavior instead, ensuring spawning happens at deterministic tick boundaries.
+
+### TickWathcerService
+
+`TickWathcerService` (`BeaverBuddies/TickWatcherService.cs`) is a simple `ITickableSingleton` that counts ticks and tracks time. It provides:
+
+- **`TicksSinceLoad`** -- Counter incremented each tick.
+- **`TotalTimeInFixedSeconds`** -- Derived from `IDayNightCycle.HoursPassedToday`, converts the in-game time to seconds.
+
+Note: This service predates the tick counting in `ReplayService` and appears to be largely superseded by it. The `ReplayService` manages its own `ticksSinceLoad` counter that serves as the authoritative tick count for synchronization.
+
+---
+
+## Tick Lifecycle Summary
+
+A complete tick cycle during multiplayer proceeds as follows:
+
+```
+Frame starts
+  |
+  v
+TickableBucketService.TickBuckets() called by Timberborn
+  |
+  v
+[Harmony Prefix] -> TickingService.TickBuckets() takes over
+  |
+  v
+ShouldTick() check passes
+  |
+  v
+Bucket index == 0, ReplayService not yet ticked
+  |
+  +-- Finish parallel ticks from prior tick
+  +-- ReplayService.DoTick()
+  |     |
+  |     +-- ticksSinceLoad++
+  |     +-- Enqueue HeartbeatEvent (server only)
+  |     +-- DoTickIO()
+  |     |     +-- ReplayEvents()
+  |     |     |     +-- Read events from IO
+  |     |     |     +-- Dequeue local events
+  |     |     |     +-- Verify RNG state per event
+  |     |     |     +-- Execute each event
+  |     |     |     +-- Record successful events for sending
+  |     |     +-- SendEvents()
+  |     |           +-- Group events into GroupedEvent
+  |     |           +-- Write to EventIO
+  |     +-- UpdateSpeed()
+  |     +-- StopAcceptingClients() (server, tick 1 only)
+  |
+  v
+HasTickedReplayService = false (on next bucket-0 entry)
+  |
+  v
+Normal entity bucket ticking proceeds...
+  Bucket 0 -> Bucket 1 -> ... -> Bucket N-1
+  |
+  v
+ShouldTick() returns false (all allocated buckets processed)
+  |
+  v
+OnTickingCompleted()
+  +-- Reset ShouldInterruptTicking
+  +-- Execute FinishFullTickAndThen callbacks (if any)
+  |
+  v
+Frame ends
+```
+
+### Client Tick Gating
+
+The client has an additional gate: `IsReadyToStartTick` checks whether events exist for the next tick (`TicksSinceLoad + 1`). If the server has not yet sent a heartbeat for that tick, `ShouldTick()` returns false and the client waits. Combined with the speed management in `UpdateSpeed()` (which pauses when `IsOutOfEvents` is true), this ensures clients never run ahead of the server.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,152 @@
+# User Guide
+
+This page covers installing, configuring, and playing BeaverBuddies as a player. For developer documentation, see the [Getting Started](getting-started) guide.
+
+## Features
+
+- Players work together to build a beaver civilization in real-time
+- Each player has their own camera and user interface
+- All resources and abilities are shared, similar to co-op in Stardew Valley, Factorio, or Parkitect
+- Players who want more independence can create their own [Districts](https://timberborn.fandom.com/wiki/Districts) to control separate areas while still trading resources
+- Host and connect from in-game menus
+- Supports both direct TCP connections and Steam peer-to-peer networking
+
+> **Note**: BeaverBuddies is under active development. You may experience desyncs or crashes. The mod may not work on the most complex saves yet. Help improve the mod by [reporting bugs](https://github.com/thomaswp/BeaverBuddies/issues).
+
+## Installing BeaverBuddies
+
+### Steam (Recommended)
+
+1. Go to the [BeaverBuddies Steam Workshop page](https://steamcommunity.com/sharedfiles/filedetails/?id=3293380223)
+2. Click **Subscribe**
+3. Launch Timberborn - the mod should appear in your Mods list:
+
+![Mod selection screen](https://github.com/user-attachments/assets/82489f01-3624-45ec-923a-cd214d843295)
+
+4. Disable other mods, as they are likely incompatible with BeaverBuddies
+
+### Non-Steam
+
+The recommended method is using the [Mod Manager](https://mod.io/g/timberborn/m/mod-manager):
+
+1. Install the Mod Manager mod (see [this guide from Mod.io](https://mod.io/g/timberborn/r/how-to-install-mods))
+2. Open Timberborn and click the "Mod manager" button in the main menu
+3. Search for "Beaver Buddies" and click **Download**
+
+![Mod Manager search](https://github.com/thomaswp/BeaverBuddies/assets/1750176/9dcfbdb6-7465-43e9-9b54-a31e07db1a15)
+
+4. Disable other mods
+5. Restart Timberborn
+
+Without the Mod Manager:
+
+1. Download the latest release from [Mod.io](https://mod.io/g/timberborn/m/beaverbuddies)
+2. Install using the [Mod.io installation guide](https://mod.io/g/timberborn/r/how-to-install-mods)
+
+## Network Setup
+
+BeaverBuddies supports two networking modes. Crossplay between the two modes is supported for 3+ player sessions.
+
+### Option 1: Steam Peer-to-Peer (Easiest)
+
+When the host starts a game, they can invite players via Steam. This uses [Steam's peer-to-peer networking](https://help.steampowered.com/en/faqs/view/1433-AD20-F11D-B71E) and requires no port forwarding. Both players must have the Steam version of Timberborn.
+
+- Pros: No network configuration needed
+- Cons: Slightly slower than direct TCP, requires Steam, still in beta
+
+### Option 2: Direct TCP (Port Forwarding)
+
+The host forwards port **25565** (configurable in Settings) to their computer. See the [Port Forwarding Guide](port-forwarding) for detailed instructions.
+
+- Pros: Faster, more reliable, works without Steam
+- Cons: Requires port forwarding setup
+
+If you don't want to port forward, you can use tools like [Hamachi](https://vpn.net/) to simulate LAN play.
+
+## Running a Game
+
+### As the Host
+
+1. Find your public IP address (e.g., from [icanhazip.com](https://icanhazip.com/)) and share it with the client
+2. If starting fresh, create a new game, save it, and exit to the main menu
+3. From the main menu, select **Load Game** and find your save
+4. Click the **Host co-op game** button (instead of "Load"):
+
+![Host co-op game button](https://github.com/thomaswp/BeaverBuddies/assets/1750176/f999cf5b-7362-4c2c-b06c-de2efa7e092f)
+
+5. Invite the client:
+   - **Steam**: Use the Steam invite dialog, or they can join via the Steam chat menu
+   - **Direct connect**: Share your IP address for them to enter
+6. Wait for the client to appear in your list of joined players:
+
+![Waiting for players dialog](https://github.com/user-attachments/assets/e12eda1a-091d-484b-b449-25508fdad605)
+
+7. Click **Start Game**
+8. Unpause and play!
+
+### As the Client
+
+1. Launch Timberborn and wait for the host to start hosting
+2. Connect to the host:
+   - **Direct connect**: Click **Join co-op game**, enter the host's IP address, and click OK
+   - **Steam**: Accept the host's invitation or right-click their name in Steam chat and join their game
+3. You'll automatically receive the save file and start loading
+4. Once loaded, let the host know you're ready
+5. Unpause and play!
+
+## Troubleshooting
+
+### The client can't connect to the server
+
+- Verify the host's **current** IP address (it may have changed since last session)
+- If using direct connect, verify port forwarding is working. The host can check at [yougetsignal.com](https://www.yougetsignal.com/tools/open-ports/) by entering their port (default: 25565)
+- If using a non-default port, make sure both host and client have the correct port configured in Settings
+- If Steam P2P isn't working, try direct TCP as a fallback
+
+### The client desynced
+
+1. Have the host **save the game** immediately
+2. You should be able to reload from that save
+3. Consider [filing a bug report](https://github.com/thomaswp/BeaverBuddies/issues) using the "Bug Report" template
+
+Tips to reduce desyncs:
+- Make sure the host has loaded a fresh save and has **not unpaused** before the client connects
+- If loading an older save with lots of progress, try starting a new game instead to isolate the issue
+- Make sure no other mods are running alongside BeaverBuddies
+- If you can identify what action caused the desync, include that in your bug report
+
+### The game crashed
+
+File a [bug report](https://github.com/thomaswp/BeaverBuddies/issues). **Don't restart** either player's game before gathering logs, as that will delete the log files that help diagnose the issue.
+
+## FAQ
+
+### How many players does the game support?
+
+Theoretically any number, but it's only been tested with 2. Support for more players is planned.
+
+### Does the mod work cross-platform (Windows and Mac)?
+
+Some users have reported success. If you run into problems, [let us know](https://github.com/thomaswp/BeaverBuddies/issues).
+
+### Will this mod break my save file?
+
+We **strongly** recommend backing up saves before using any mod. BeaverBuddies does not directly change your save files, so there should be no permanent damage. Crashes may lose temporary work, but autosave functions normally. We recommend starting with a new save for multiplayer.
+
+### What other mods work with BeaverBuddies?
+
+Currently, using other mods with BeaverBuddies is discouraged as they will likely cause desyncs. Simple mods that don't involve randomness or UI actions *might* work if both host and client install them, but this is not officially supported.
+
+### Do both players need to own Timberborn?
+
+Yes. Both players need their own copy.
+
+### How do I stop using co-op mode?
+
+- If installed via Steam Workshop, simply unsubscribe or disable it in the mod list
+- If installed via Mod Manager, disable it there
+- Otherwise, remove the BeaverBuddies folder from your mods folder
+
+### How can I suggest a feature?
+
+Create a [new issue](https://github.com/thomaswp/BeaverBuddies/issues) using the "Feature request" template. The goal of BeaverBuddies is intentionally limited to supporting the main game in co-op mode.


### PR DESCRIPTION
It took me quite a while to get up to speed on the project so I thought it would be helpful for everyone here to have developer documentation. I prefer github pages over wiki format as it is easier to track changes and make updates on the fly.

Yes, I absolutely used AI agents to help generate this but worked from a template I've been using across many projects. I checked for accuracy to the best of my abilities but ideally someone more familiar with the codebase could verify. At the very least, it contains full coverage for all existing documentation. That being said, given the use of AI tools to generate this, I won't be offended if my PR is denied.

You can see it working on my fork: [matthewwachter.github.io/BeaverBuddies](https://matthewwachter.github.io/BeaverBuddies/#/)

Features:
  - Adds a Docsify-based documentation site in docs/ with 14 pages covering the full codebase
  - Includes player-facing guides (installation, port forwarding, troubleshooting, FAQ) migrated from the wiki
  - Includes developer guides (architecture, event system, networking, tick sync, determinism, connection flow, multiplayer maps, configuration, testing, contributing, etc.)

  Test plan:

- [ ]   - Preview locally with docsify serve docs or python -m http.server in docs/
- [ ]   - Verify all sidebar links resolve
- [ ]   - Check developer documentation for accuracy
- [ ]   - Verify C# code blocks have syntax highlighting
- [ ]   - Enable GitHub Pages from the docs/ folder in repo settings