### PR TITLE
Fix reconnect crash (EOCD) and building-placement NullReferenceException

### DIFF
--- a/BeaverBuddies/Connect/ClientConnectionService.cs
+++ b/BeaverBuddies/Connect/ClientConnectionService.cs
@@ -176,8 +176,31 @@ namespace BeaverBuddies.Connect
                 .Show();
         }
 
+        // A valid Timberborn save is a ZIP archive, which always begins with the
+        // local-file-header magic "PK\x03\x04". When the connection to the host
+        // drops or is refused, the client can receive a short non-map payload
+        // (an error/handshake message) as its "first message". Feeding those
+        // bytes into the save loader throws
+        // "End of Central Directory record could not be found" *during scene
+        // load* (so it can't be caught here) and crashes the game. Reject
+        // anything that isn't a real save before we ever start loading it.
+        private static bool IsValidMap(byte[] mapBytes)
+        {
+            return mapBytes != null && mapBytes.Length >= 4 &&
+                mapBytes[0] == 0x50 && mapBytes[1] == 0x4B &&
+                mapBytes[2] == 0x03 && mapBytes[3] == 0x04;
+        }
+
         private void LoadMap(byte[] mapBytes)
         {
+            if (!IsValidMap(mapBytes))
+            {
+                Plugin.LogError($"Received invalid map data ({mapBytes?.Length ?? 0} bytes); " +
+                    "the host likely disconnected. Aborting load instead of crashing.");
+                ShowError(null);
+                return;
+            }
+
             // Clean up our current co-op state before loading,
             // so we don't, for example, end up ticking the client before
             // it's actually loaded.

--- a/BeaverBuddies/Events/ReplayEvent.cs
+++ b/BeaverBuddies/Events/ReplayEvent.cs
@@ -72,7 +72,20 @@ namespace BeaverBuddies.Events
 
         public static string GetEntityID(BaseComponent component)
         {
-            return component?.GetComponent<EntityComponent>()?.EntityId.ToString();
+            if (component == null) return null;
+            try
+            {
+                return component.GetComponent<EntityComponent>()?.EntityId.ToString();
+            }
+            catch (Exception)
+            {
+                // The component may not be fully initialized/registered as an
+                // entity yet (e.g. a duplication source while a tool is mid-use),
+                // in which case GetComponent throws internally in ComponentCache
+                // instead of returning null. Treat that as "no entity" so the
+                // caller falls back to the base behaviour instead of crashing.
+                return null;
+            }
         }
 
         protected BuildingSpec GetBuilding(IReplayContext context, string buildingName)


### PR DESCRIPTION
Fixes two independent crashes observed on Timberborn 1.0.13.1 / BeaverBuddies 1.7.1.

Fixes #193
Fixes #194

## 1. Reconnect crash — "End of Central Directory record could not be found" (#193)

After the host connection drops (`SocketException: Connection refused`), the client receives a short non-map payload (e.g. 213 bytes; real maps are ~420–460 KB) as its "first message". `ClientConnectionService.LoadMap` writes those bytes into a save and loads them, so `ZipArchive` throws **during scene load** (outside `LoadMap`, so a local try/catch can't catch it) and the game crashes.

**Fix:** validate the received bytes before loading — a Timberborn save is a ZIP, so it must start with the local-file-header magic `PK\x03\x04` and have a minimum length. If the data isn't a valid save, show the existing connection-failed dialog (`ShowError(null)`) instead of loading a bogus save.

## 2. NullReferenceException in `ReplayEvent.GetEntityID` (#194)

When placing/duplicating a building, `GetEntityID(DuplicationSource)` calls `component.GetComponent<EntityComponent>()`, which throws internally in `ComponentCache.GetIndex<T>()` when the component isn't registered as an entity yet. The existing `?.` only guards a *null* `component`, not an exception thrown *inside* `GetComponent`.

**Fix:** catch the exception and return `null`; callers already treat a null entity ID as "not an entity" and fall back to the base behaviour.

## Notes

- Both changes are minimal and defensive; no protocol changes, so a patched client stays compatible with an unpatched host (and vice-versa).
- Verified the project builds against Timberborn 1.0.13.1 (`Release Steam`). I was not able to run an extensive multi-machine co-op session, so a second pair of eyes on the reconnect path is welcome.
- Diagnosed from five `Error reports/*.zip` crash dumps; details and logs are in the linked issues.

Co-authored with assistance from Claude Code.
