### PR TITLE
Add coordinated late joining and crash fixes

### DIFF
--- a/BeaverBuddies.sln
+++ b/BeaverBuddies.sln
@@ -20,6 +20,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Inspector", "Inspector\Inspector.csproj", "{0515AAAB-9D23-4433-A179-AE5064C7A04A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TimberNet.IntegrationTests", "TimberNet.IntegrationTests\TimberNet.IntegrationTests.csproj", "{2945492A-9D32-48C0-B238-5FE10558EB4A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug Steam|Any CPU = Debug Steam|Any CPU
@@ -52,6 +54,14 @@ Global
 		{0515AAAB-9D23-4433-A179-AE5064C7A04A}.Release Steam|Any CPU.Build.0 = Release|Any CPU
 		{0515AAAB-9D23-4433-A179-AE5064C7A04A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0515AAAB-9D23-4433-A179-AE5064C7A04A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2945492A-9D32-48C0-B238-5FE10558EB4A}.Debug Steam|Any CPU.ActiveCfg = Debug|Any CPU
+		{2945492A-9D32-48C0-B238-5FE10558EB4A}.Debug Steam|Any CPU.Build.0 = Debug|Any CPU
+		{2945492A-9D32-48C0-B238-5FE10558EB4A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2945492A-9D32-48C0-B238-5FE10558EB4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2945492A-9D32-48C0-B238-5FE10558EB4A}.Release Steam|Any CPU.ActiveCfg = Release|Any CPU
+		{2945492A-9D32-48C0-B238-5FE10558EB4A}.Release Steam|Any CPU.Build.0 = Release|Any CPU
+		{2945492A-9D32-48C0-B238-5FE10558EB4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2945492A-9D32-48C0-B238-5FE10558EB4A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/BeaverBuddies/BeaverBuddies.csproj
+++ b/BeaverBuddies/BeaverBuddies.csproj
@@ -17,7 +17,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>BeaverBuddies</AssemblyName>
     <Description>TimberModTest</Description>
-    <Version>1.7.1</Version>
+    <Version>1.7.3</Version>
     <TimberbornTargetVersion>1.0</TimberbornTargetVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>

--- a/BeaverBuddies/Connect/ClientConnectionService.cs
+++ b/BeaverBuddies/Connect/ClientConnectionService.cs
@@ -15,11 +15,27 @@ using Timberborn.WebNavigation;
 using TimberNet;
 using System.Linq;
 using Timberborn.SettlementNameSystem;
+using System.Collections.Concurrent;
 
 namespace BeaverBuddies.Connect
 {
     public class ClientConnectionService : IUpdatableSingleton
     {
+        private const int ReconnectRetryDelayFrames = 30;
+        private static readonly TimeSpan ReconnectTimeout = TimeSpan.FromMinutes(2);
+        private static readonly object ReconnectLock = new object();
+        private static readonly ConcurrentQueue<Tuple<string, string>> PendingErrors =
+            new ConcurrentQueue<Tuple<string, string>>();
+
+        // These are static because Timberborn replaces scene singletons while a
+        // save is loading. The reconnect target must survive that replacement.
+        private static Func<ISocketStream> reconnectSocketFactory;
+        private static bool reconnectActive;
+        private static bool reconnectAttemptInProgress;
+        private static bool reconnectDisconnectCurrent;
+        private static DateTime reconnectDeadlineUtc;
+        private static int reconnectDelayFrames;
+
         private GameSceneLoader _gameSceneLoader;
         private GameSaveRepository _gameSaveRepository;
         private DialogBoxShower _dialogBoxShower;
@@ -44,7 +60,9 @@ namespace BeaverBuddies.Connect
 
         public bool TryToConnect(CSteamID friendID)
         {
-            return TryToConnect(new SteamSocket(friendID));
+            Func<ISocketStream> socketFactory = () => new SteamSocket(friendID);
+            PrepareManualConnection(socketFactory);
+            return TryToConnect(socketFactory(), false);
         }
 
         public bool TryToConnect(string address)
@@ -86,16 +104,71 @@ namespace BeaverBuddies.Connect
                 }
             }
 
-            return TryToConnect(new TCPClientWrapper(address, port));
+            string finalAddress = address;
+            int finalPort = port;
+            Func<ISocketStream> socketFactory = () => new TCPClientWrapper(finalAddress, finalPort);
+            PrepareManualConnection(socketFactory);
+            return TryToConnect(socketFactory(), false);
         }
 
-        private bool TryToConnect(ISocketStream socket)
+        private static void PrepareManualConnection(Func<ISocketStream> socketFactory)
+        {
+            lock (ReconnectLock)
+            {
+                reconnectSocketFactory = socketFactory;
+                reconnectActive = false;
+                reconnectAttemptInProgress = false;
+                reconnectDisconnectCurrent = false;
+            }
+        }
+
+        private static void RequestSessionReconnect()
+        {
+            lock (ReconnectLock)
+            {
+                if (reconnectSocketFactory == null)
+                {
+                    Plugin.LogError("A session reload was requested without a reconnect target");
+                    return;
+                }
+
+                if (!reconnectActive)
+                {
+                    reconnectDeadlineUtc = DateTime.UtcNow + ReconnectTimeout;
+                    Plugin.Log("Session is reloading; reconnecting automatically");
+                }
+                reconnectActive = true;
+                reconnectDisconnectCurrent = true;
+                reconnectDelayFrames = ReconnectRetryDelayFrames;
+            }
+        }
+
+        private static void FinishSessionReconnect()
+        {
+            lock (ReconnectLock)
+            {
+                reconnectActive = false;
+                reconnectAttemptInProgress = false;
+                reconnectDisconnectCurrent = false;
+            }
+        }
+
+        private bool TryToConnect(ISocketStream socket, bool automatic)
         {
             Plugin.Log("Connecting client");
             client = ClientEventIO.Create(socket, LoadMap, (error) =>
             {
-                ShowError("BeaverBuddies.JoinCoopGame.Error.CouldNotConnect", error);
-            });
+                client = null;
+                if (automatic || error == TimberNetBase.SESSION_RESTART_REQUIRED)
+                {
+                    RequestSessionReconnect();
+                }
+                else
+                {
+                    PendingErrors.Enqueue(Tuple.Create(
+                        "BeaverBuddies.JoinCoopGame.Error.CouldNotConnect", error));
+                }
+            }, RequestSessionReconnect);
             
             if (client == null)
             {
@@ -176,8 +249,31 @@ namespace BeaverBuddies.Connect
                 .Show();
         }
 
+        private static bool IsValidMap(byte[] mapBytes)
+        {
+            // Timberborn saves are ZIP archives. Reject connection/control data
+            // before handing it to the asynchronous game loader, where a bad
+            // archive would otherwise crash with an EOCD exception.
+            return mapBytes != null && mapBytes.Length >= 4 &&
+                mapBytes[0] == 0x50 && mapBytes[1] == 0x4B &&
+                mapBytes[2] == 0x03 && mapBytes[3] == 0x04;
+        }
+
         private void LoadMap(byte[] mapBytes)
         {
+            if (!IsValidMap(mapBytes))
+            {
+                Plugin.LogError($"Received invalid map data ({mapBytes?.Length ?? 0} bytes); " +
+                    "the host likely disconnected. Aborting load instead of crashing.");
+                ShowError(null);
+                FinishSessionReconnect();
+                EventIO.Reset();
+                client = null;
+                return;
+            }
+
+            FinishSessionReconnect();
+
             // Clean up our current co-op state before loading,
             // so we don't, for example, end up ticking the client before
             // it's actually loaded.
@@ -199,9 +295,88 @@ namespace BeaverBuddies.Connect
 
         public void UpdateSingleton()
         {
-            if (client == null) return;
-            //Plugin.Log("Updating client!");
-            client.Update();
+            while (PendingErrors.TryDequeue(out Tuple<string, string> error))
+            {
+                ShowError(error.Item1, error.Item2);
+            }
+
+            // This instance owns a connection while joining from the menu. Once
+            // the game scene loads, ReplayService updates the shared EventIO.
+            client?.Update();
+
+            Func<ISocketStream> socketFactory = null;
+            bool disconnectCurrent = false;
+            bool timedOut = false;
+            lock (ReconnectLock)
+            {
+                if (!reconnectActive || reconnectAttemptInProgress)
+                {
+                    return;
+                }
+
+                if (DateTime.UtcNow >= reconnectDeadlineUtc)
+                {
+                    reconnectActive = false;
+                    reconnectDisconnectCurrent = false;
+                    timedOut = true;
+                }
+                else
+                {
+                    disconnectCurrent = reconnectDisconnectCurrent;
+                    reconnectDisconnectCurrent = false;
+
+                    if (reconnectDelayFrames > 0)
+                    {
+                        reconnectDelayFrames--;
+                    }
+                    else if (client == null)
+                    {
+                        socketFactory = reconnectSocketFactory;
+                        reconnectAttemptInProgress = true;
+                    }
+                }
+            }
+
+            if (disconnectCurrent)
+            {
+                EventIO.Reset();
+                client = null;
+            }
+
+            if (timedOut)
+            {
+                EventIO.Reset();
+                client = null;
+                ShowError("BeaverBuddies.JoinCoopGame.Error.CouldNotConnect",
+                    "The host did not finish reloading within two minutes.");
+                return;
+            }
+
+            if (socketFactory == null)
+            {
+                return;
+            }
+
+            bool connected = false;
+            try
+            {
+                connected = TryToConnect(socketFactory(), true);
+            }
+            catch (Exception exception)
+            {
+                Plugin.LogError($"Automatic reconnect failed: {exception}");
+            }
+            finally
+            {
+                lock (ReconnectLock)
+                {
+                    reconnectAttemptInProgress = false;
+                    if (!connected && reconnectActive)
+                    {
+                        reconnectDelayFrames = ReconnectRetryDelayFrames;
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/BeaverBuddies/Connect/RehostingService.cs
+++ b/BeaverBuddies/Connect/RehostingService.cs
@@ -94,14 +94,19 @@ namespace BeaverBuddies.Connect
             return true;
         }
 
-        public bool RehostGame()
+        public bool RehostGame(Action beforeReload = null, int minimumReadyClients = 0)
         {
-            return SaveRehostFile(LoadGame, true);
+            return SaveRehostFile(saveReference =>
+            {
+                beforeReload?.Invoke();
+                LoadGame(saveReference, minimumReadyClients);
+            }, true);
         }
 
-        public void LoadGame(SaveReference saveReference)
+        public void LoadGame(SaveReference saveReference, int minimumReadyClients = 0)
         {
-            ServerHostingUtils.LoadIfSaveValidAndHost(_validatingGameLoader, _dialogBoxShower, saveReference);
+            ServerHostingUtils.LoadIfSaveValidAndHost(
+                _validatingGameLoader, _dialogBoxShower, saveReference, minimumReadyClients);
         }
     }
 }

--- a/BeaverBuddies/Connect/ServerHostingUtils.cs
+++ b/BeaverBuddies/Connect/ServerHostingUtils.cs
@@ -70,9 +70,10 @@ namespace BeaverBuddies.Connect
 
     internal class ServerHostingUtils
     {
-        public static void LoadIfSaveValidAndHost(ValidatingGameLoader loader, DialogBoxShower shower, SaveReference saveReferece)
+        public static void LoadIfSaveValidAndHost(ValidatingGameLoader loader, DialogBoxShower shower,
+            SaveReference saveReferece, int minimumReadyClients = 0)
         {
-            CheckNextValidator(loader, shower, saveReferece, 0);
+            CheckNextValidator(loader, shower, saveReferece, 0, minimumReadyClients);
         }
 
         [ManualMethodOverwrite]
@@ -88,16 +89,17 @@ namespace BeaverBuddies.Connect
 	        CheckNextValidator(saveReference, index + 1);
         });
          */
-        private static void CheckNextValidator(ValidatingGameLoader loader, DialogBoxShower shower, SaveReference saveReference, int index)
+        private static void CheckNextValidator(ValidatingGameLoader loader, DialogBoxShower shower,
+            SaveReference saveReference, int index, int minimumReadyClients)
         {
             if (index >= loader._gameLoadValidators.Length)
             {
-                LoadAndHost(loader, shower, saveReference);
+                LoadAndHost(loader, shower, saveReference, minimumReadyClients);
                 return;
             }
             loader._gameLoadValidators[index].ValidateSave(saveReference, delegate
             {
-                CheckNextValidator(loader, shower, saveReference, index + 1);
+                CheckNextValidator(loader, shower, saveReference, index + 1, minimumReadyClients);
             });
         }
 
@@ -138,7 +140,8 @@ namespace BeaverBuddies.Connect
             return ((SceneLoader)loader)._coroutineStarter._monoBehaviour;
         }
 
-        public static void LoadAndHost(ValidatingGameLoader loader, DialogBoxShower shower, SaveReference saveReference)
+        public static void LoadAndHost(ValidatingGameLoader loader, DialogBoxShower shower,
+            SaveReference saveReference, int minimumReadyClients = 0)
         {
             var sceneLoader = loader._gameSceneLoader;
             var repository = sceneLoader._gameSaveRepository;
@@ -147,7 +150,7 @@ namespace BeaverBuddies.Connect
 
             ServerEventIO io = new ServerEventIO();
             EventIO.Set(io);
-            io.Start(data);
+            io.Start(data, minimumReadyClients);
 
             var behavior = GetMonoBehaviour(sceneLoader._sceneLoader);
             Coroutine coroutine = null;

--- a/BeaverBuddies/DeterminismService.cs
+++ b/BeaverBuddies/DeterminismService.cs
@@ -750,9 +750,16 @@ namespace BeaverBuddies
             }
             replayService.FinishFullTickIfNeededAndThen(() =>
             {
+                bool wasSaving = IsSaving;
                 IsSaving = true;
-                original(instance, queuedSave);
-                IsSaving = false;
+                try
+                {
+                    original(instance, queuedSave);
+                }
+                finally
+                {
+                    IsSaving = wasSaving;
+                }
             });
         }
     }
@@ -761,11 +768,20 @@ namespace BeaverBuddies
     public class AutosaverCreateExitSavePatcher
     {
 
-        static void Prefix()
+        static void Prefix(out bool __state)
         {
             // Go straight to saving since we're going to exit
             // and don't need to keep clients in sync
+            __state = GameSaverSavePatcher.IsSaving;
             GameSaverSavePatcher.IsSaving = true;
+        }
+
+        static Exception Finalizer(Exception __exception, bool __state)
+        {
+            // CreateExitSave is synchronous. Restore the prior state even when
+            // the save fails so returning to the menu cannot poison the next game.
+            GameSaverSavePatcher.IsSaving = __state;
+            return __exception;
         }
     }
 

--- a/BeaverBuddies/Events/ReplayEvent.cs
+++ b/BeaverBuddies/Events/ReplayEvent.cs
@@ -72,7 +72,18 @@ namespace BeaverBuddies.Events
 
         public static string GetEntityID(BaseComponent component)
         {
-            return component?.GetComponent<EntityComponent>()?.EntityId.ToString();
+            if (component == null) return null;
+            try
+            {
+                return component.GetComponent<EntityComponent>()?.EntityId.ToString();
+            }
+            catch (Exception)
+            {
+                // Some components (notably a duplication source while its tool is
+                // mid-use) are not registered as entities yet. Treat those as
+                // non-entities so callers can use their existing fallback path.
+                return null;
+            }
         }
 
         protected BuildingSpec GetBuilding(IReplayContext context, string buildingName)

--- a/BeaverBuddies/IO/ClientEventIO.cs
+++ b/BeaverBuddies/IO/ClientEventIO.cs
@@ -20,17 +20,25 @@ namespace BeaverBuddies.IO
         public override UserEventBehavior UserEventBehavior => UserEventBehavior.Send;
 
         private MapReceived mapReceivedCallback;
+        private Action sessionRestartCallback;
         private bool FailedToConnect = false;
 
+        public void NotifyLoaded()
+        {
+            NetBase?.NotifyLoaded();
+        }
+
         private ClientEventIO(ISocketStream socket, MapReceived mapReceivedCallback,
-            Action<string> onError)
+            Action<string> onError, Action onSessionRestart)
         {
             this.mapReceivedCallback = mapReceivedCallback;
+            sessionRestartCallback = onSessionRestart;
 
             TryRegisterSteamPacketReceiver(socket);
 
             NetBase = new TimberClient(socket);
             NetBase.OnMapReceived += mapReceivedCallback;
+            NetBase.OnSessionRestart += sessionRestartCallback;
             NetBase.OnLog += Plugin.Log;
             NetBase.OnError += (error) =>
             {
@@ -56,13 +64,16 @@ namespace BeaverBuddies.IO
         {
             if (NetBase == null) return;
             NetBase.OnMapReceived -= mapReceivedCallback;
+            NetBase.OnSessionRestart -= sessionRestartCallback;
             NetBase.OnLog -= Plugin.Log;
+            NetBase.Close();
             NetBase = null;
         }
 
-        public static ClientEventIO Create(ISocketStream socket, MapReceived mapReceivedCallback, Action<string> onError)
+        public static ClientEventIO Create(ISocketStream socket, MapReceived mapReceivedCallback,
+            Action<string> onError, Action onSessionRestart)
         {
-            ClientEventIO eventIO = new ClientEventIO(socket, mapReceivedCallback, onError);
+            ClientEventIO eventIO = new ClientEventIO(socket, mapReceivedCallback, onError, onSessionRestart);
             if (eventIO.FailedToConnect) return null;
             return eventIO;
         }

--- a/BeaverBuddies/IO/ServerEventIO.cs
+++ b/BeaverBuddies/IO/ServerEventIO.cs
@@ -8,18 +8,13 @@ using System.Net.Sockets;
 using UnityEngine;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace BeaverBuddies.IO
 {
-    // With TimberBorn's current architecture, we cannot feasibly
-    // support joining after the game has started. This is because a number
-    // of variables are randomly initialized during load (e.g. tree lifespans)
-    // rather than serialized, since they aren't that important. As a result, the
-    // save won't create the same gamestate as a currently loaded game. The only
-    // way to ensure that the gamestate is the same is to have all clients join
-    // at load time.
-    // Barring a complete overhaul of how loading works, I should probably disable
-    // joining after the play button is first pressed.
+    // A client joining a running session causes an on-demand rehost. Every peer
+    // then loads the same checkpoint, avoiding Timberborn state that is not fully
+    // represented by a save until all peers reconstruct it through the same load.
     public class ServerEventIO : NetIOBase<TimberServer>
     {
         // Anything that happens on the server should be recorded and
@@ -36,8 +31,14 @@ namespace BeaverBuddies.IO
 
         public ISocketListener SocketListener { get; private set; }
 
-        // We only support a static map; see note above
-        public void Start(byte[] mapBytes)
+        public bool AreAllClientsReady => NetBase == null || NetBase.AreAllClientsReady;
+        public int ClientCount => NetBase?.ClientCount ?? 0;
+
+        private int lateJoinRequested;
+
+        // The map remains static for this synchronization epoch. A late join
+        // creates a new checkpoint and therefore a new ServerEventIO instance.
+        public void Start(byte[] mapBytes, int minimumReadyClients = 0)
         {
             try
             {
@@ -69,7 +70,8 @@ namespace BeaverBuddies.IO
                         task.Start();
                         return task;
                     },
-                    CreateInitEvent()
+                    CreateInitEvent(),
+                    minimumReadyClients
                 );
             }
             catch (Exception e)
@@ -81,7 +83,28 @@ namespace BeaverBuddies.IO
             //netBase = new TimberServer(port, mapProvider, null);
             NetBase.OnLog += Plugin.Log;
             NetBase.OnMapReceived += NetBase_OnClientConnected;
+            NetBase.OnLateJoinRequested += () => Interlocked.Exchange(ref lateJoinRequested, 1);
             NetBase.Start();
+        }
+
+        public bool TryConsumeLateJoinRequest()
+        {
+            return Interlocked.Exchange(ref lateJoinRequested, 0) == 1;
+        }
+
+        public void MarkGameStarted()
+        {
+            NetBase?.MarkGameStarted();
+        }
+
+        public void NotifySessionRestart()
+        {
+            NetBase?.NotifySessionRestart();
+        }
+
+        public void CancelSessionRestart()
+        {
+            NetBase?.CancelSessionRestart();
         }
 
         private Func<JObject> CreateInitEvent()
@@ -97,15 +120,6 @@ namespace BeaverBuddies.IO
                 Plugin.Log($"Sending start state: {JsonSettings.Serialize(message)}");
                 return JObject.Parse(JsonSettings.Serialize(message));
             };
-        }
-
-        public void StopAcceptingClients()
-        {
-            Plugin.Log("Game started: no longer accepting clients");
-            string message = $"The Host has already started the game, and the game can no longer be joined. " +
-                $"Ask the Host to rehost and join before they unpause.";
-            NetBase.StopAcceptingClients(message);
-            // TODO: remove map from memory
         }
 
         private void NetBase_OnClientConnected(byte[] mapBytes)

--- a/BeaverBuddies/ReplayService.cs
+++ b/BeaverBuddies/ReplayService.cs
@@ -84,6 +84,7 @@ namespace BeaverBuddies
         private readonly ISingletonRepository _singletonRepository;
         private readonly TickingService _tickingService;
         private readonly DeterminismService _determinismService;
+        private readonly RehostingService _rehostingService;
 
         private readonly GameSaveHelper gameSaveHelper;
 
@@ -123,12 +124,25 @@ namespace BeaverBuddies
             {
                 // The client shouldn't tick until the server has sent a heartbeat
                 // Check the *next* tick, since current tick has already happened
-                return !(io is ClientEventIO && !io.HasEventsForTick(TicksSinceLoad + 1));
+                if (io is ClientEventIO && !io.HasEventsForTick(TicksSinceLoad + 1))
+                {
+                    return false;
+                }
+
+                // The server must not send its first heartbeat or start simulation
+                // until every connected client has finished loading the same save.
+                if (io is ServerEventIO server && !server.AreAllClientsReady)
+                {
+                    return false;
+                }
+
+                return true;
             }
         }
 
         public static bool IsLoaded { get; private set; } = false;
         private bool isReset = false;
+        private bool coordinatedRehostStarted = false;
 
         private bool CanAct => io != null && !isReset && !IsDesynced;
 
@@ -142,6 +156,7 @@ namespace BeaverBuddies
             IsLoaded = false;
             IsReplayingEvents = false;
             isReset = true;
+            coordinatedRehostStarted = false;
         }
 
         public ReplayService(
@@ -201,7 +216,7 @@ namespace BeaverBuddies
             AddSingleton(optionsBox);
             AddSingleton(dialogBoxShower);
             AddSingleton(urlOpener);
-            AddSingleton(rehostingService);
+            _rehostingService = AddSingleton(rehostingService);
             AddSingleton(reportingService);
             AddSingleton(gameSaveRepository);
             AddSingleton(mapNameService);
@@ -436,6 +451,13 @@ namespace BeaverBuddies
             DesyncDetecterService.StartTick(ticksSinceLoad);
 
             IsLoaded = true;
+
+            // Loading and its initial randomization are now complete. Let the host
+            // release its first-tick barrier for this client.
+            if (io is ClientEventIO client)
+            {
+                client.NotifyLoaded();
+            }
         }
 
         // TODO: Find a better callback way of waiting until initial game
@@ -463,7 +485,50 @@ namespace BeaverBuddies
             {
                 DoTickIO();
             }
+            TryStartCoordinatedRehost();
             UpdateSpeed();
+        }
+
+        private void TryStartCoordinatedRehost()
+        {
+            if (coordinatedRehostStarted ||
+                !(io is ServerEventIO server) ||
+                !server.TryConsumeLateJoinRequest())
+            {
+                return;
+            }
+
+            coordinatedRehostStarted = true;
+            Plugin.Log("Late client requested a coordinated reload; finishing the current tick");
+            FinishFullTickIfNeededAndThen(() =>
+            {
+                if (!(io is ServerEventIO currentServer))
+                {
+                    coordinatedRehostStarted = false;
+                    return;
+                }
+
+                TargetSpeed = 0;
+                SpeedChangePatcher.SetSpeedSilentlyNow(_speedManager, 0);
+
+                // Consume any messages that reached the host before the checkpoint.
+                // Every peer will load the resulting save, so no historical replay
+                // is needed across synchronization epochs.
+                currentServer.Update();
+                DoTickIO();
+
+                int minimumReadyClients = currentServer.ClientCount + 1;
+                bool started = _rehostingService.RehostGame(() =>
+                {
+                    currentServer.NotifySessionRestart();
+                }, minimumReadyClients);
+                if (!started)
+                {
+                    currentServer.CancelSessionRestart();
+                    coordinatedRehostStarted = false;
+                    Plugin.LogError("Could not save a checkpoint for the late-joining client");
+                }
+            });
         }
 
         public void SetTargetSpeed(float speed)
@@ -555,10 +620,11 @@ namespace BeaverBuddies
             // Update speed and pause if needed for the new tick.
             UpdateSpeed();
 
-            if (io is ServerEventIO && ticksSinceLoad == 1)
+            if (io is ServerEventIO server && ticksSinceLoad == 1)
             {
-                ((ServerEventIO)io).StopAcceptingClients();
+                server.MarkGameStarted();
             }
+
         }
 
         public void FinishFullTickIfNeededAndThen(Action action)

--- a/BeaverBuddies/changelog.txt
+++ b/BeaverBuddies/changelog.txt
@@ -1,3 +1,12 @@
+v1.7.3
+* A client joining a running session now triggers an on-demand checkpoint reload. Existing players reconnect automatically and everyone loads the same checkpoint before play resumes, without periodic state snapshots or unbounded event history.
+
+v1.7.2
+* Fixed false desyncs after returning to the main menu by correctly clearing save-in-progress state.
+* The host now waits for every connected client to finish loading before starting the first simulation tick.
+* Invalid reconnect payloads are now rejected instead of being loaded as saves and crashing with a ZIP error.
+* Fixed a crash when placing or duplicating a building whose source is not yet registered as an entity.
+
 v1.7.1
 * A changelog will now appear on version updates (that's this window!).
 * New Feature: Players can now ping the map. Open Settings->Keybindings and choose a binding for "Ping Location" to ping in game and all players will see it. Credit: @SamuZad

--- a/BeaverBuddies/manifest.json
+++ b/BeaverBuddies/manifest.json
@@ -1,6 +1,6 @@
 {
   "Name": "BeaverBuddies - Multiplayer Co-Op",
-  "Version": "1.7.1",
+  "Version": "1.7.3",
   "Id": "beaverbuddies",
   "MinimumGameVersion": "1.0.0.0",
   "Description": "BeaverBuddies is a Timberborn mod that adds multiplayer co-op!",

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@
 
 BeaverBuddies is a mod to allow multiplayer co-op in Timberborn.
 
+## Fork Attribution
+
+This repository is a fork of the original
+[BeaverBuddies project](https://github.com/thomaswp/BeaverBuddies), created by
+[@thomaswp](https://github.com/thomaswp). The upstream Git history, copyright
+notices, and GNU GPL v3 license are preserved.
+
 > [!IMPORTANT]
 > **If you would like to use the BeaverBuddies mod**, please see [the setup instructions in the wiki](https://github.com/thomaswp/BeaverBuddies/wiki)! This README is for developers.
 

--- a/TimberNet.IntegrationTests/Program.cs
+++ b/TimberNet.IntegrationTests/Program.cs
@@ -1,0 +1,182 @@
+using System.Net;
+using System.Net.Sockets;
+using Newtonsoft.Json.Linq;
+using TimberNet;
+
+internal static class Program
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+    private static int Main()
+    {
+        TimberServer? server = null;
+        TimberClient? firstClient = null;
+        TimberClient? lateClient = null;
+        TimberClient? duplicateLateClient = null;
+        TimberClient? retriedLateClient = null;
+        try
+        {
+            int port = FindAvailablePort();
+            byte[] map = { 0x50, 0x4B, 0x03, 0x04, 1, 2, 3, 4 };
+            int restartRequests = 0;
+
+            server = new TimberServer(
+                new TCPListenerWrapper(port),
+                () => Task.FromResult(map),
+                () => CreateEvent(0, "IntegrationTestInitialize"),
+                minimumReadyClients: 1);
+            server.OnLateJoinRequested += () => Interlocked.Increment(ref restartRequests);
+            server.Start();
+            AssertEqual(false, server.AreAllClientsReady,
+                "minimum-client ready barrier before reconnect");
+
+            firstClient = ConnectClient(port);
+            WaitForMap(firstClient);
+            firstClient.NotifyLoaded();
+            WaitUntil(
+                () => firstClient.HasEventsForTick(0),
+                firstClient.Update,
+                "initial client did not receive its initialization event");
+            firstClient.ReadEvents(0);
+            WaitUntil(
+                () => server.AreAllClientsReady,
+                server.Update,
+                "initial client never reached the ready barrier");
+            AssertEqual(server.Hash, firstClient.Hash, "initial client hash");
+
+            bool restartNotificationReceived = false;
+            firstClient.OnSessionRestart += () => restartNotificationReceived = true;
+            server.MarkGameStarted();
+
+            string? lateError = null;
+            lateClient = ConnectClient(port, error => lateError = error);
+            WaitUntil(
+                () => Volatile.Read(ref lateError) != null,
+                lateClient.Update,
+                "late client was not told to wait for a checkpoint reload");
+            AssertEqual(
+                TimberNetBase.SESSION_RESTART_REQUIRED,
+                lateError,
+                "late-join retry signal");
+            WaitUntil(
+                () => Volatile.Read(ref restartRequests) == 1,
+                server.Update,
+                "late join did not request a coordinated reload");
+            AssertEqual(1, server.ClientCount, "registered client count after late join");
+
+            int serverHashBeforeControlMessage = server.Hash;
+            int clientHashBeforeControlMessage = firstClient.Hash;
+            server.NotifySessionRestart();
+            WaitUntil(
+                () => restartNotificationReceived,
+                firstClient.Update,
+                "existing client did not receive the reload notification");
+            AssertEqual(serverHashBeforeControlMessage, server.Hash,
+                "server hash after reload control message");
+            AssertEqual(clientHashBeforeControlMessage, firstClient.Hash,
+                "client hash after reload control message");
+
+            // Many automatic retries can hit the old server while the host is
+            // loading. They must not schedule multiple saves/reloads.
+            string? duplicateError = null;
+            duplicateLateClient = ConnectClient(port, error => duplicateError = error);
+            WaitUntil(
+                () => Volatile.Read(ref duplicateError) != null,
+                duplicateLateClient.Update,
+                "duplicate retry did not receive the reload signal");
+            AssertEqual(1, Volatile.Read(ref restartRequests),
+                "duplicate coordinated reload request count");
+
+            // If checkpoint creation fails, the host can release the guard and
+            // the next retry is allowed to request another attempt.
+            server.CancelSessionRestart();
+            string? retriedError = null;
+            retriedLateClient = ConnectClient(port, error => retriedError = error);
+            WaitUntil(
+                () => Volatile.Read(ref retriedError) != null,
+                retriedLateClient.Update,
+                "retry after a cancelled reload did not receive the reload signal");
+            WaitUntil(
+                () => Volatile.Read(ref restartRequests) == 2,
+                server.Update,
+                "cancelled coordinated reload could not be retried");
+
+            Console.WriteLine(
+                "PASS: running sessions reject late joins, coalesce reload requests, " +
+                "and notify existing clients without changing the deterministic hash.");
+            return 0;
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine($"FAIL: {exception}");
+            return 1;
+        }
+        finally
+        {
+            retriedLateClient?.Close();
+            duplicateLateClient?.Close();
+            lateClient?.Close();
+            firstClient?.Close();
+            server?.Close();
+        }
+    }
+
+    private static JObject CreateEvent(int tick, string type)
+    {
+        return new JObject
+        {
+            [TimberNetBase.TICKS_KEY] = tick,
+            [TimberNetBase.TYPE_KEY] = type,
+            ["value"] = tick,
+        };
+    }
+
+    private static TimberClient ConnectClient(int port, Action<string>? onError = null)
+    {
+        var client = new TimberClient(new TCPClientWrapper("127.0.0.1", port));
+        if (onError != null)
+        {
+            client.OnError += message => onError(message);
+        }
+        client.Start();
+        return client;
+    }
+
+    private static void WaitForMap(TimberClient client)
+    {
+        bool received = false;
+        client.OnMapReceived += _ => received = true;
+        WaitUntil(() => received, client.Update, "client did not receive the map");
+    }
+
+    private static void WaitUntil(Func<bool> condition, Action pump, string failure)
+    {
+        DateTime deadline = DateTime.UtcNow + Timeout;
+        while (!condition())
+        {
+            if (DateTime.UtcNow >= deadline)
+            {
+                throw new TimeoutException(failure);
+            }
+            pump();
+            Thread.Sleep(5);
+        }
+    }
+
+    private static int FindAvailablePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static void AssertEqual<T>(T expected, T actual, string description)
+    {
+        if (!EqualityComparer<T>.Default.Equals(expected, actual))
+        {
+            throw new Exception($"{description}: expected {expected}, got {actual}");
+        }
+    }
+}

--- a/TimberNet.IntegrationTests/TimberNet.IntegrationTests.csproj
+++ b/TimberNet.IntegrationTests/TimberNet.IntegrationTests.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TimberNet\TimberNet.csproj" />
+  </ItemGroup>
+</Project>

--- a/TimberNet/TimberClient.cs
+++ b/TimberNet/TimberClient.cs
@@ -17,6 +17,11 @@ namespace TimberNet
     {
 
         private readonly ISocketStream client;
+        private string? readyToken;
+        private bool hasFinishedLoading;
+        private bool readyNotificationSent;
+
+        public event Action? OnSessionRestart;
 
         public override bool ShouldTick => base.ShouldTick && receivedEvents.Count > 0;
 
@@ -30,6 +35,47 @@ namespace TimberNet
             // Don't actually do the event (i.e. add it to the hash)
             // Wait for the server to confirm w/ adjusted Tick
             SendEvent(client, message);
+        }
+
+        protected override void ReceiveEvent(JObject message)
+        {
+            string type = GetType(message);
+            if (type == SET_STATE_EVENT)
+            {
+                readyToken = message[READY_TOKEN_KEY]?.ToObject<string>();
+                TryNotifyLoaded();
+            }
+            else if (type == SESSION_RESTART_EVENT)
+            {
+                Log("Host requested a coordinated session reload");
+                OnSessionRestart?.Invoke();
+                return;
+            }
+            base.ReceiveEvent(message);
+        }
+
+        public void NotifyLoaded()
+        {
+            hasFinishedLoading = true;
+            // Process any state message that arrived while the game scene loaded.
+            Update();
+            TryNotifyLoaded();
+        }
+
+        private void TryNotifyLoaded()
+        {
+            if (!hasFinishedLoading || readyNotificationSent || string.IsNullOrEmpty(readyToken))
+            {
+                return;
+            }
+
+            JObject message = new JObject();
+            message[TICKS_KEY] = TickCount;
+            message[TYPE_KEY] = CLIENT_READY_EVENT;
+            message[READY_TOKEN_KEY] = readyToken;
+            SendEvent(client, message);
+            readyNotificationSent = true;
+            Log("Notified server that loading finished");
         }
 
         protected override void ProcessReceivedEvent(JObject message)

--- a/TimberNet/TimberNetBase.cs
+++ b/TimberNet/TimberNetBase.cs
@@ -22,6 +22,10 @@ namespace TimberNet
         public const string TYPE_KEY = "type";
         public const string SET_STATE_EVENT = "SetState";
         public const string HEARTBEAT_EVENT = "Heartbeat";
+        public const string CLIENT_READY_EVENT = "ClientReady";
+        public const string SESSION_RESTART_EVENT = "SessionRestart";
+        public const string SESSION_RESTART_REQUIRED = "BeaverBuddies.SessionRestartRequired";
+        public const string READY_TOKEN_KEY = "readyToken";
         public const int MAX_BUFFER_SIZE = 8192 * 4; // 32K
 
         public delegate void MessageReceived(string message);

--- a/TimberNet/TimberServer.cs
+++ b/TimberNet/TimberServer.cs
@@ -1,55 +1,140 @@
-﻿using System;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Sockets;
-using System.Net;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
-using System.Collections.Concurrent;
-using Newtonsoft.Json.Linq;
-using System.IO;
-using System.Security.Cryptography;
 
 namespace TimberNet
-{ 
-
+{
     public class TimberServer : TimberNetBase
     {
-
         private readonly List<ISocketStream> clients = new List<ISocketStream>();
         private readonly ConcurrentDictionary<ISocketStream, ConcurrentQueue<JObject>> queuedMessages =
             new ConcurrentDictionary<ISocketStream, ConcurrentQueue<JObject>>();
+        private readonly Dictionary<ISocketStream, string> clientReadyTokens =
+            new Dictionary<ISocketStream, string>();
+        private readonly HashSet<string> readyClients = new HashSet<string>();
+        private readonly int minimumReadyClients;
 
         private readonly ISocketListener listener;
-
         private Func<Task<byte[]>> mapProvider;
         private Func<JObject>? initEventProvider;
+        private int nextReadyToken;
+        private int coordinatedRestartRequested;
+        private bool gameStarted;
 
-        public int ClientCount => clients.Count;
+        private string? errorMessage;
 
-        private string? errorMessage = null;
-        public bool IsAcceptingClients => errorMessage == null;
+        public event Action? OnLateJoinRequested;
 
-        public List<string?> GetConnectedClients()
+        public int ClientCount
         {
-            return clients.Select(c => c.Name).ToList();
+            get
+            {
+                lock (queuedMessages)
+                {
+                    RemoveDisconnectedClients();
+                    return clients.Count;
+                }
+            }
         }
 
-        public TimberServer(ISocketListener listener, Func<Task<byte[]>> mapProvider, Func<JObject>? initEventProvider)
+        public bool AreAllClientsReady
+        {
+            get
+            {
+                lock (queuedMessages)
+                {
+                    RemoveDisconnectedClients();
+                    return clients.Count >= minimumReadyClients && clients.All(client =>
+                        clientReadyTokens.TryGetValue(client, out string? token) &&
+                        readyClients.Contains(token));
+                }
+            }
+        }
+
+        public bool IsAcceptingClients => errorMessage == null;
+
+        public TimberServer(
+            ISocketListener listener,
+            Func<Task<byte[]>> mapProvider,
+            Func<JObject>? initEventProvider,
+            int minimumReadyClients = 0)
         {
             this.listener = listener;
             this.mapProvider = mapProvider;
             this.initEventProvider = initEventProvider;
+            this.minimumReadyClients = minimumReadyClients;
         }
 
-        public void UpdateProviders(Func<Task<byte[]>> mapProvider, Func<JObject>? initEventProvider)
+        public List<string?> GetConnectedClients()
+        {
+            lock (queuedMessages)
+            {
+                RemoveDisconnectedClients();
+                return clients.Select(client => client.Name).ToList();
+            }
+        }
+
+        public void UpdateProviders(
+            Func<Task<byte[]>> mapProvider,
+            Func<JObject>? initEventProvider)
         {
             this.mapProvider = mapProvider;
             this.initEventProvider = initEventProvider;
         }
 
+        public void MarkGameStarted()
+        {
+            lock (queuedMessages)
+            {
+                gameStarted = true;
+            }
+            Log("Session is running; future joins will create a coordinated checkpoint");
+        }
+
+        public void CancelSessionRestart()
+        {
+            Interlocked.Exchange(ref coordinatedRestartRequested, 0);
+        }
+
+        public void NotifySessionRestart()
+        {
+            JObject message = new JObject
+            {
+                [TICKS_KEY] = TickCount,
+                [TYPE_KEY] = SESSION_RESTART_EVENT,
+            };
+
+            lock (queuedMessages)
+            {
+                RemoveDisconnectedClients();
+                clients.ForEach(client => SendEvent(client, message));
+            }
+        }
+
         protected override void ReceiveEvent(JObject message)
         {
+            if (GetType(message) == CLIENT_READY_EVENT)
+            {
+                string? token = message[READY_TOKEN_KEY]?.ToObject<string>();
+                lock (queuedMessages)
+                {
+                    if (token != null && clientReadyTokens.Values.Contains(token))
+                    {
+                        readyClients.Add(token);
+                        Log($"Client finished loading ({readyClients.Count}/{clients.Count})");
+                    }
+                    else
+                    {
+                        Log("Ignoring client-ready message with an invalid token");
+                    }
+                }
+                return;
+            }
+
             message[TICKS_KEY] = TickCount;
             base.ReceiveEvent(message);
         }
@@ -57,15 +142,11 @@ namespace TimberNet
         public override void Start()
         {
             base.Start();
-
             listener.Start();
             Log("Server started listening");
-            
+
             Task.Run(() =>
             {
-                // TODO: I have a suspicion that this while plus the catch/continue below
-                // is responsible for the server hanging sometimes on a connection that's dropped.
-                // Logging now to see if I can catch it.
                 while (!IsStopped)
                 {
                     ISocketStream client;
@@ -73,39 +154,87 @@ namespace TimberNet
                     {
                         Log("Accepting client...");
                         client = listener.AcceptClient();
-                    } catch (Exception e)
+                    }
+                    catch (Exception exception)
                     {
-                        Log("Error accepting client.");
-                        Log(e.StackTrace);
+                        if (!IsStopped)
+                        {
+                            Log($"Error accepting client: {exception}");
+                        }
                         continue;
                     }
-                    Task.Run(async () =>
-                    {
-                        if (!IsAcceptingClients)
-                        {
-                            SendErrorMessage(client);
-                            client.Close();
-                            return;
-                        }
 
-                        await SendMap(client);
-                        SendState(client);
-                        if (initEventProvider != null)
-                        {
-                            JObject initEvent = initEventProvider();
-                            // Send the event before finishing queueing
-                            // so it is guaranteed to arrive first.
-                            // (This also sends it to other clients.)
-                            DoUserInitiatedEvent(initEvent, true);
-                        }
-                        FinishQueuing(client);
-
-                        // This must come last - it is an infinite loop
-                        // until the client disconnects
-                        StartListening(client, false);
-                    });
+                    Task.Run(async () => await SetUpClient(client));
                 }
             });
+        }
+
+        private async Task SetUpClient(ISocketStream client)
+        {
+            bool clientRegistered = false;
+            try
+            {
+                if (!IsAcceptingClients)
+                {
+                    SendErrorMessage(client, errorMessage!);
+                    return;
+                }
+
+                if (!TryStartQueuing(client))
+                {
+                    RequestCoordinatedRestart();
+                    SendErrorMessage(client, SESSION_RESTART_REQUIRED);
+                    return;
+                }
+                clientRegistered = true;
+
+                await SendMap(client);
+                SendState(client);
+                if (initEventProvider != null)
+                {
+                    // Broadcast the initialization event so every peer advances
+                    // the event hash in the same order.
+                    DoUserInitiatedEvent(initEventProvider(), true);
+                }
+                FinishQueuing(client);
+
+                // This blocks until the client disconnects.
+                StartListening(client, false);
+            }
+            catch (Exception exception)
+            {
+                Log($"Client setup failed: {exception}");
+            }
+            finally
+            {
+                if (clientRegistered)
+                {
+                    lock (queuedMessages)
+                    {
+                        RemoveClient(client);
+                    }
+                }
+                client.Close();
+            }
+        }
+
+        private void RequestCoordinatedRestart()
+        {
+            if (Interlocked.CompareExchange(ref coordinatedRestartRequested, 1, 0) != 0)
+            {
+                return;
+            }
+
+            Log("Late join requested; scheduling a coordinated checkpoint reload");
+            try
+            {
+                OnLateJoinRequested?.Invoke();
+            }
+            catch (Exception exception)
+            {
+                Interlocked.Exchange(ref coordinatedRestartRequested, 0);
+                Log($"Late-join callback failed: {exception}");
+            }
         }
 
         public void StopAcceptingClients(string errorMessage)
@@ -113,99 +242,102 @@ namespace TimberNet
             this.errorMessage = errorMessage;
         }
 
-        private void StartQueuing (ISocketStream client)
+        private bool TryStartQueuing(ISocketStream client)
         {
             lock (queuedMessages)
             {
+                // This check and registration are atomic with MarkGameStarted.
+                // A client either joins the original load barrier or triggers a
+                // new checkpoint; it can never slip into a running simulation.
+                if (gameStarted)
+                {
+                    return false;
+                }
+
                 queuedMessages.TryAdd(client, new ConcurrentQueue<JObject>());
                 clients.Add(client);
+                clientReadyTokens.Add(client, (++nextReadyToken).ToString());
+                return true;
+            }
+        }
+
+        private void RemoveClient(ISocketStream client)
+        {
+            if (clientReadyTokens.TryGetValue(client, out string? token))
+            {
+                readyClients.Remove(token);
+                clientReadyTokens.Remove(client);
+            }
+            queuedMessages.TryRemove(client, out _);
+            clients.Remove(client);
+        }
+
+        private void RemoveDisconnectedClients()
+        {
+            for (int index = clients.Count - 1; index >= 0; index--)
+            {
+                ISocketStream client = clients[index];
+                if (!client.Connected)
+                {
+                    RemoveClient(client);
+                }
             }
         }
 
         private void FinishQueuing(ISocketStream client)
         {
-            // Log("finishing queuing");
-            lock(queuedMessages)
+            lock (queuedMessages)
             {
-                if (queuedMessages.TryGetValue(client, out ConcurrentQueue<JObject> queue))
+                if (!queuedMessages.TryGetValue(client, out ConcurrentQueue<JObject> queue))
                 {
-                    // Log($"Found {queue.Count} messages");
-                    while (queue.TryDequeue(out JObject message))
-                    {
-                        // Log(message.ToString());
-                        SendEvent(client, message);
-                    }
-                    queuedMessages.TryRemove(client, out _);
+                    Log("Warning! Missing client queue");
+                    return;
                 }
-                else
+
+                while (queue.TryDequeue(out JObject message))
                 {
-                    Log("Warning! Missing client!");
+                    SendEvent(client, message);
                 }
+                queuedMessages.TryRemove(client, out _);
             }
         }
 
-        private void SendErrorMessage(ISocketStream client)
+        private void SendErrorMessage(ISocketStream client, string message)
         {
             SendLength(client, 0);
-            byte[] bytes = MessageToBuffer(errorMessage!);
-            // TODO: Not sure this makes sense for Steam
-            SendDataWithLength(client, bytes);
+            SendDataWithLength(client, MessageToBuffer(message));
         }
 
         private async Task SendMap(ISocketStream client)
-        { 
-            Task<byte[]> task = mapProvider();
+        {
             Log("Waiting for map...");
-            byte[] mapBytes = await task;
-
-            // TODO: This may happen a bit early - it seems possible for
-            // events from a prior frame to get queued. Maybe just need to filter
-            // them on the client side.
-            // Start recording messages as soon as the map is saved,
-            // while the map is sending
-            StartQueuing(client);
-
+            byte[] mapBytes = await mapProvider();
             Log($"Sending map with length {mapBytes.Length}");
             SendDataWithLength(client, mapBytes);
-
-            Log($"Sent map with length {mapBytes.Length} and Hash: {GetHashCode(mapBytes).ToString("X8")}");
+            Log($"Sent map with length {mapBytes.Length} and Hash: {GetHashCode(mapBytes):X8}");
         }
 
         private void SendState(ISocketStream client)
         {
-            JObject message = new JObject();
-            message[TICKS_KEY] = 0;
-            message[TYPE_KEY] = SET_STATE_EVENT;
-            message["hash"] = Hash;
-            // Send directly - don't queue
+            JObject message = new JObject
+            {
+                [TICKS_KEY] = 0,
+                [TYPE_KEY] = SET_STATE_EVENT,
+                ["hash"] = Hash,
+            };
+            lock (queuedMessages)
+            {
+                message[READY_TOKEN_KEY] = clientReadyTokens[client];
+            }
             SendEvent(client, message);
         }
 
-        void DoUserInitiatedEvent(JObject message, bool sendNow)
+        private void DoUserInitiatedEvent(JObject message, bool sendNow)
         {
             base.DoUserInitiatedEvent(message);
-            SendEventToClients(message, sendNow);
-        }
-
-        public override void DoUserInitiatedEvent(JObject message)
-        {
-            DoUserInitiatedEvent(message, false);
-        }
-
-        private void SendEventToClients(JObject message, bool sendNow)
-        {
-            for (int i = 0; i < clients.Count; i++)
-            {
-                if (!clients[i].Connected)
-                {
-                    clients.RemoveAt(i);
-                    i--;
-                }
-            }
-            // Make sure we're not running this while a client is being
-            // setup to start or stop queueing
             lock (queuedMessages)
             {
+                RemoveDisconnectedClients();
                 clients.ForEach(client =>
                 {
                     if (sendNow)
@@ -214,15 +346,23 @@ namespace TimberNet
                     }
                     else
                     {
-                        QueueOrSentToClient(client, message);
+                        QueueOrSendToClient(client, message);
                     }
                 });
             }
         }
 
-        private void QueueOrSentToClient(ISocketStream client, JObject message)
+        public override void DoUserInitiatedEvent(JObject message)
         {
-            if (!client.Connected) return;
+            DoUserInitiatedEvent(message, false);
+        }
+
+        private void QueueOrSendToClient(ISocketStream client, JObject message)
+        {
+            if (!client.Connected)
+            {
+                return;
+            }
 
             if (queuedMessages.TryGetValue(client, out ConcurrentQueue<JObject> queue))
             {
@@ -237,30 +377,31 @@ namespace TimberNet
         public override void Close()
         {
             base.Close();
-            try
+            lock (queuedMessages)
             {
-                clients.ForEach(client => client.Close());
-            }
-            catch (Exception e)
-            {
-                Log(e.ToString());
+                clients.ToList().ForEach(client => client.Close());
+                clients.Clear();
+                queuedMessages.Clear();
+                clientReadyTokens.Clear();
+                readyClients.Clear();
             }
             try
             {
                 listener.Stop();
             }
-            catch (Exception e)
+            catch (Exception exception)
             {
-                Log(e.ToString());
-            }  
+                Log(exception.ToString());
+            }
         }
 
         public void SendHeartbeat()
         {
-            JObject message = new JObject();
-            message[TICKS_KEY] = TickCount;
-            message[TYPE_KEY] = HEARTBEAT_EVENT;
-            // Simulate the user doing this
+            JObject message = new JObject
+            {
+                [TICKS_KEY] = TickCount,
+                [TYPE_KEY] = HEARTBEAT_EVENT,
+            };
             DoUserInitiatedEvent(message);
         }
     }


### PR DESCRIPTION
## Summary

- fix the save-state leak and unregistered-entity crashes seen in the supplied logs
- prevent the host from starting simulation until every connected client has loaded
- allow a client to join a running session through an on-demand coordinated checkpoint reload
- reject invalid save payloads before Timberborn's ZIP loader can crash

## Late-join design

A late connection receives a structured retry response instead of an old map. The host coalesces repeated retries, finishes the current tick, flushes received events, saves one checkpoint, and starts a fresh synchronization epoch. Existing clients receive a control message and automatically reconnect; the late client keeps retrying for up to two minutes. The new host epoch requires the previously connected clients plus the late joiner to finish loading before simulation can resume.

This avoids periodic state snapshots and unbounded event-history replay. Every peer reconstructs Timberborn's non-serialized load-time state from the same checkpoint.

## Attribution

The README explicitly attributes the original BeaverBuddies project to `@thomaswp`; upstream history, notices, and GPL-3.0 licensing remain intact.

## Verification

- `dotnet run --project TimberNet.IntegrationTests/TimberNet.IntegrationTests.csproj -c Release`
- `dotnet build BeaverBuddies.sln -c "Release Steam"`
- `git diff --check`
